### PR TITLE
[Auth] Inscription email/username avec mot de passe haché

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ go.work.sum
 # env file
 .env
 
+CLAUDE.md
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/api/auth-service/README.md
+++ b/api/auth-service/README.md
@@ -7,7 +7,7 @@ Handles authentication and account management for Hypertube.
 - User registration and login
 - JWT access + refresh token issuance and rotation
 - Token blacklisting on logout (Redis)
-- Email verification (6-digit code)
+- Email verification (6-digit code, sent automatically on registration)
 - Password reset via email link
 
 ## Endpoints
@@ -21,10 +21,163 @@ Handles authentication and account management for Hypertube.
 | `POST` | `/api/v1/auth/logout` | JWT | Invalidate access token |
 | `POST` | `/api/v1/auth/refresh` | — | Exchange refresh token for new pair |
 | `GET` | `/api/v1/auth/verify` | JWT | Verify token validity |
-| `POST` | `/api/v1/auth/send-email-verification` | — | Send verification code by email |
+| `POST` | `/api/v1/auth/send-email-verification` | — | Re-send verification code |
 | `POST` | `/api/v1/auth/verify-email` | — | Submit verification code |
 | `POST` | `/api/v1/auth/forgot-password` | — | Send password reset email |
 | `POST` | `/api/v1/auth/reset-password` | — | Reset password with token |
+
+### POST /api/v1/auth/register
+
+```json
+// Request
+{
+  "username":   "jdoe",
+  "email":      "jane@example.com",
+  "password":   "min8chars",
+  "first_name": "Jane",
+  "last_name":  "Doe"
+}
+
+// 201 Created
+{
+  "success": true,
+  "data": {
+    "message":       "User registered successfully",
+    "user":          { "id": 1, "username": "jdoe", "email": "jane@example.com" },
+    "access_token":  "<jwt>",
+    "refresh_token": "<jwt>",
+    "token_type":    "Bearer",
+    "expires_in":    21600
+  }
+}
+```
+
+A verification code is sent to the email address immediately after registration. The account is usable before verification, but downstream services may gate features on `email_verified`.
+
+Errors: `409` username taken (+ suggestions) · `409` email taken · `400` invalid payload
+
+### POST /api/v1/auth/login
+
+```json
+// Request — login accepts username or email
+{ "login": "jdoe", "password": "min8chars" }
+
+// 200 OK — same shape as /register
+```
+
+Errors: `401` invalid credentials
+
+### POST /api/v1/auth/logout
+
+Header: `Authorization: Bearer <access_token>`
+
+```json
+// 200 OK
+{ "success": true, "data": { "message": "logged out successfully" } }
+```
+
+Adds the token to the Redis blacklist with a TTL equal to its remaining lifetime.
+
+### POST /api/v1/auth/refresh
+
+```json
+// Request
+{ "refresh_token": "<jwt>" }
+
+// 200 OK — rotated pair
+{
+  "success": true,
+  "data": {
+    "access_token":  "<jwt>",
+    "refresh_token": "<jwt>",
+    "token_type":    "Bearer",
+    "expires_in":    21600
+  }
+}
+```
+
+Errors: `401` invalid or wrong-scope token
+
+### GET /api/v1/auth/verify
+
+Header: `Authorization: Bearer <access_token>`
+
+```json
+// 200 OK
+{ "success": true, "data": { "valid": true, "user_id": "1" } }
+```
+
+Errors: `401` missing/invalid/expired token
+
+### POST /api/v1/auth/check-availability
+
+```json
+// Request — at least one field required
+{ "username": "jdoe", "email": "jane@example.com" }
+
+// 200 OK
+{ "status": "success", "available": true }
+
+// 409 Conflict — username taken
+{ "status": "error", "available": false, "message": "username déjà utilisé", "suggestions": ["jdoe42", "jdoe_"] }
+
+// 409 Conflict — email taken
+{ "status": "error", "available": false, "message": "Email déjà utilisé" }
+```
+
+### POST /api/v1/auth/send-email-verification
+
+Resends a code if the account is not yet verified. The code expires after 15 minutes.
+
+```json
+// Request
+{ "email": "jane@example.com" }
+
+// 200 OK
+{ "success": true, "data": { "message": "Verification code sent successfully" } }
+```
+
+Errors: `404` user not found · `400` already verified
+
+### POST /api/v1/auth/verify-email
+
+```json
+// Request
+{ "email": "jane@example.com", "verification_code": "482931" }
+
+// 200 OK
+{ "success": true, "data": { "message": "Email verified successfully" } }
+```
+
+Errors: `400` invalid code · `400` expired code
+
+### POST /api/v1/auth/forgot-password
+
+Always responds with success to prevent user enumeration.
+
+```json
+// Request
+{ "email": "jane@example.com" }
+
+// 200 OK
+{ "success": true, "data": { "message": "If the email exists, a password reset link will be sent" } }
+```
+
+### POST /api/v1/auth/reset-password
+
+Token is valid for 1 hour and single-use.
+
+```json
+// Request
+{ "token": "<reset_token>", "new_password": "newmin8chars" }
+
+// 200 OK
+{ "success": true, "data": { "message": "Password reset successful" } }
+```
+
+Errors: `400` invalid/expired token · `400` same as current password
+
+---
 
 ## Token flow
 
@@ -41,6 +194,8 @@ POST /logout    (Authorization: Bearer <token>)
 
 The gateway validates every access token and forwards `X-User-ID` to downstream services.
 
+---
+
 ## Environment variables
 
 | Variable | Default | Description |
@@ -54,6 +209,9 @@ The gateway validates every access token and forwards `X-User-ID` to downstream 
 | `REDIS_HOST` | `redis` | Redis host (token blacklist) |
 | `REDIS_PORT` | `6379` | Redis port |
 | `JWT_SECRET` | — | **Required.** Secret for signing JWTs |
+| `JWT_ACCESS_TTL` | `6h` | Access token lifetime |
+| `JWT_REFRESH_TTL` | `168h` | Refresh token lifetime |
+| `JWT_REFRESH_SECRET` | `JWT_SECRET` | Separate secret for refresh tokens (optional) |
 | `SMTP_HOST` | `smtp.gmail.com` | SMTP server |
 | `SMTP_PORT` | `587` | SMTP port |
 | `SMTP_USERNAME` | — | SMTP login |
@@ -64,6 +222,8 @@ The gateway validates every access token and forwards `X-User-ID` to downstream 
 | `AUTO_MIGRATE` | `false` | Run GORM AutoMigrate on start |
 
 If `SMTP_USERNAME` or `SMTP_PASSWORD` is empty, emails are printed to stdout instead of being sent (dev mode).
+
+---
 
 ## Layout
 

--- a/api/auth-service/src/handlers/auth.go
+++ b/api/auth-service/src/handlers/auth.go
@@ -15,8 +15,6 @@ import (
 	"auth-service/src/utils"
 )
 
-
-// CheckAvailabilityHandler handles username/email availability checks
 func CheckAvailabilityHandler(c *gin.Context) {
 	var req types.AvailabilityRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -24,61 +22,48 @@ func CheckAvailabilityHandler(c *gin.Context) {
 		return
 	}
 
-	// At least one field must be provided
 	if req.Username == "" && req.Email == "" {
 		utils.RespondError(c, http.StatusBadRequest, "either username or email must be provided")
 		return
 	}
 
-	// Check username availability
 	if req.Username != "" {
 		available, err := utils.CheckUsernameAvailability(req.Username)
 		if err != nil {
 			utils.RespondError(c, http.StatusInternalServerError, err.Error())
 			return
 		}
-		
 		if !available {
 			suggestions := utils.GenerateUsernameSuggestions(req.Username)
-			response := types.AvailabilityResponse{
+			c.JSON(http.StatusConflict, types.AvailabilityResponse{
 				Status:      "error",
 				Available:   false,
 				Message:     "username déjà utilisé",
 				Suggestions: suggestions,
-			}
-			c.JSON(http.StatusConflict, response)
+			})
 			return
 		}
 	}
 
-	// Check email availability
 	if req.Email != "" {
 		available, err := utils.CheckEmailAvailability(req.Email)
 		if err != nil {
 			utils.RespondError(c, http.StatusInternalServerError, err.Error())
 			return
 		}
-		
 		if !available {
-			response := types.AvailabilityResponse{
+			c.JSON(http.StatusConflict, types.AvailabilityResponse{
 				Status:    "error",
 				Available: false,
 				Message:   "Email déjà utilisé",
-			}
-			c.JSON(http.StatusConflict, response)
+			})
 			return
 		}
 	}
 
-	// Both fields are available
-	response := types.AvailabilityResponse{
-		Status:    "success",
-		Available: true,
-	}
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, types.AvailabilityResponse{Status: "success", Available: true})
 }
 
-// RegisterHandler handles user registration
 func RegisterHandler(c *gin.Context) {
 	var req types.RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -86,7 +71,6 @@ func RegisterHandler(c *gin.Context) {
 		return
 	}
 
-	// Check username uniqueness
 	usernameAvailable, err := utils.CheckUsernameAvailability(req.Username)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
@@ -98,7 +82,6 @@ func RegisterHandler(c *gin.Context) {
 		return
 	}
 
-	// Check email uniqueness
 	emailAvailable, err := utils.CheckEmailAvailability(req.Email)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
@@ -109,7 +92,6 @@ func RegisterHandler(c *gin.Context) {
 		return
 	}
 
-	// Create user
 	user, err := services.CreateUser(req)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
@@ -120,7 +102,6 @@ func RegisterHandler(c *gin.Context) {
 		fmt.Printf("Failed to queue verification email for %s: %v\n", user.Email, err)
 	}
 
-	// Generate tokens
 	tokens, err := utils.GenerateTokenPair(user.ID)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
@@ -141,7 +122,6 @@ func RegisterHandler(c *gin.Context) {
 	})
 }
 
-// LoginHandler handles user login
 func LoginHandler(c *gin.Context) {
 	var req types.LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -149,20 +129,17 @@ func LoginHandler(c *gin.Context) {
 		return
 	}
 
-	// Find user by username or email
 	var user models.Users
 	if err := db.DB.Where("username = ? OR email = ?", req.Login, req.Login).First(&user).Error; err != nil || user.ID == 0 {
 		utils.RespondError(c, http.StatusUnauthorized, "invalid credentials")
 		return
 	}
 
-	// Compare password
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
 		utils.RespondError(c, http.StatusUnauthorized, "invalid credentials")
 		return
 	}
 
-	// Issue JWT & refresh tokens
 	tokens, err := utils.GenerateTokenPair(user.ID)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())

--- a/api/auth-service/src/handlers/auth.go
+++ b/api/auth-service/src/handlers/auth.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -113,6 +114,10 @@ func RegisterHandler(c *gin.Context) {
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	if err := sendVerificationCode(user.Email); err != nil {
+		fmt.Printf("Failed to queue verification email for %s: %v\n", user.Email, err)
 	}
 
 	// Generate tokens

--- a/api/auth-service/src/handlers/email_verification.go
+++ b/api/auth-service/src/handlers/email_verification.go
@@ -17,13 +17,9 @@ import (
 	"auth-service/src/utils"
 )
 
-// User alias pour models.Users
 type User = models.Users
-
-// EmailVerification alias pour models.EmailVerification  
 type EmailVerification = models.EmailVerification
 
-// generateVerificationCode generates a 6-digit verification code
 func generateVerificationCode() (string, error) {
 	const digits = "0123456789"
 	code := make([]byte, 6)
@@ -37,8 +33,8 @@ func generateVerificationCode() (string, error) {
 	return string(code), nil
 }
 
-// sendVerificationCode generates and persists a verification code, then emails it.
-// Returns an error only if code generation or DB write fails; email send failures are logged but not returned.
+// sendVerificationCode persists a verification code and emails it.
+// Email send failures are non-fatal: registration still succeeds and the code remains valid.
 func sendVerificationCode(email string) error {
 	code, err := generateVerificationCode()
 	if err != nil {
@@ -65,7 +61,6 @@ func sendVerificationCode(email string) error {
 	return nil
 }
 
-// SendEmailVerificationHandler handles sending email verification codes
 func SendEmailVerificationHandler(c *gin.Context) {
 	var req types.EmailVerificationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -73,7 +68,6 @@ func SendEmailVerificationHandler(c *gin.Context) {
 		return
 	}
 
-	// Check if user exists
 	var user User
 	if err := db.DB.Where("email = ?", req.Email).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -84,7 +78,6 @@ func SendEmailVerificationHandler(c *gin.Context) {
 		return
 	}
 
-	// Check if user is already verified
 	if user.EmailVerified {
 		utils.RespondError(c, http.StatusBadRequest, "Email already verified")
 		return
@@ -100,7 +93,6 @@ func SendEmailVerificationHandler(c *gin.Context) {
 	})
 }
 
-// VerifyEmailHandler handles email verification with code
 func VerifyEmailHandler(c *gin.Context) {
 	var req types.VerifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -108,7 +100,6 @@ func VerifyEmailHandler(c *gin.Context) {
 		return
 	}
 
-	// Find verification record
 	var verification EmailVerification
 	if err := db.DB.Where("email = ? AND verification_code = ?", req.Email, req.VerificationCode).First(&verification).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -119,21 +110,17 @@ func VerifyEmailHandler(c *gin.Context) {
 		return
 	}
 
-	// Check if code is expired
 	if time.Now().After(verification.ExpiresAt) {
-		// Delete expired verification
 		db.DB.Delete(&verification)
 		utils.RespondError(c, http.StatusBadRequest, "Verification code expired")
 		return
 	}
 
-	// Update user as verified
 	if err := db.DB.Model(&User{}).Where("email = ?", req.Email).Update("email_verified", true).Error; err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "Failed to update user verification status")
 		return
 	}
 
-	// Delete the verification record
 	db.DB.Delete(&verification)
 
 	utils.RespondSuccess(c, http.StatusOK, gin.H{

--- a/api/auth-service/src/handlers/email_verification.go
+++ b/api/auth-service/src/handlers/email_verification.go
@@ -37,6 +37,34 @@ func generateVerificationCode() (string, error) {
 	return string(code), nil
 }
 
+// sendVerificationCode generates and persists a verification code, then emails it.
+// Returns an error only if code generation or DB write fails; email send failures are logged but not returned.
+func sendVerificationCode(email string) error {
+	code, err := generateVerificationCode()
+	if err != nil {
+		return fmt.Errorf("failed to generate verification code: %w", err)
+	}
+
+	db.DB.Where("email = ?", email).Delete(&EmailVerification{})
+
+	verification := EmailVerification{
+		Email:            email,
+		VerificationCode: code,
+		ExpiresAt:        time.Now().Add(15 * time.Minute),
+	}
+	if err := db.DB.Create(&verification).Error; err != nil {
+		return fmt.Errorf("failed to create verification record: %w", err)
+	}
+
+	emailService := services.NewEmailService()
+	if err := emailService.SendVerificationEmail(email, code); err != nil {
+		fmt.Printf("Failed to send verification email to %s: %v\n", email, err)
+		fmt.Printf("Verification code for %s: %s (email failed to send)\n", email, code)
+	}
+
+	return nil
+}
+
 // SendEmailVerificationHandler handles sending email verification codes
 func SendEmailVerificationHandler(c *gin.Context) {
 	var req types.EmailVerificationRequest
@@ -62,35 +90,9 @@ func SendEmailVerificationHandler(c *gin.Context) {
 		return
 	}
 
-	// Generate verification code
-	code, err := generateVerificationCode()
-	if err != nil {
-		utils.RespondError(c, http.StatusInternalServerError, "Failed to generate verification code")
+	if err := sendVerificationCode(req.Email); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
-	}
-
-	// Create or update verification record
-	verification := EmailVerification{
-		Email:            req.Email,
-		VerificationCode: code,
-		ExpiresAt:        time.Now().Add(15 * time.Minute), // 15 minutes expiry
-	}
-
-	// Delete any existing verification for this email
-	db.DB.Where("email = ?", req.Email).Delete(&EmailVerification{})
-
-	// Create new verification record
-	if err := db.DB.Create(&verification).Error; err != nil {
-		utils.RespondError(c, http.StatusInternalServerError, "Failed to create verification record")
-		return
-	}
-
-	// Send verification email
-	emailService := services.NewEmailService()
-	if err := emailService.SendVerificationEmail(req.Email, code); err != nil {
-		// Log error but don't fail the request - code is still valid
-		fmt.Printf("Failed to send verification email to %s: %v\n", req.Email, err)
-		fmt.Printf("Verification code for %s: %s (email failed to send)\n", req.Email, code)
 	}
 
 	utils.RespondSuccess(c, http.StatusOK, gin.H{


### PR DESCRIPTION
Closes #4

## Changements

- **`sendVerificationCode`** — helper partagé extrait de `SendEmailVerificationHandler` : génère un code à 6 chiffres, le persiste en base (TTL 15 min) et l'envoie par email. L'échec d'envoi est non-fatal : l'inscription réussit quand même.
- **`RegisterHandler`** — appelle `sendVerificationCode` juste après la création du compte.
- **`SendEmailVerificationHandler`** — refactorisé pour déléguer à `sendVerificationCode`.
- Nettoyage des commentaires redondants dans `auth.go` et `email_verification.go`.
- README `auth-service` mis à jour avec les schémas requête/réponse de chaque endpoint.

## Critères d'acceptation

- [x] Champs : email, username, prénom, nom, mot de passe
- [x] Hashage du mot de passe (bcrypt)
- [x] Validation des champs côté backend (format email, longueur password ≥ 8)
- [x] Email de vérification envoyé après inscription
- [x] Retour d'erreurs explicites (email déjà pris, username déjà pris + suggestions)

## Test

```bash
# Inscription
curl -X POST http://localhost:8000/api/v1/auth/register \
  -H 'Content-Type: application/json' \
  -d '{"username":"jdoe","email":"jane@example.com","password":"secret123","first_name":"Jane","last_name":"Doe"}'
# → 201 + tokens, code de vérification dans les logs du container (dev sans SMTP)

# Doublon email
curl -X POST http://localhost:8000/api/v1/auth/register \
  -H 'Content-Type: application/json' \
  -d '{"username":"other","email":"jane@example.com","password":"secret123","first_name":"A","last_name":"B"}'
# → 409 "Email déjà utilisé"

# Vérification email
curl -X POST http://localhost:8000/api/v1/auth/verify-email \
  -H 'Content-Type: application/json' \
  -d '{"email":"jane@example.com","verification_code":"<code>"}'
# → 200
```