### PR TITLE
feat(Auth): Reset de mot de passe par email

### DIFF
--- a/api/auth-service/src/handlers_test.go
+++ b/api/auth-service/src/handlers_test.go
@@ -20,7 +20,6 @@ import (
 	db "auth-service/src/conf"
 	"auth-service/src/handlers"
 	models "auth-service/src/models"
-	types "auth-service/src/types"
 )
 
 func setupTestDB() *gorm.DB {
@@ -175,15 +174,11 @@ func TestLoginHandler(t *testing.T) {
 
 	// First create a test user
 	user := models.Users{
-		Username:         "loginuser",
-		Email:            "login@example.com",
-		PasswordHash:     "$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi", // "password"
-		FirstName:        "Login",
-		LastName:         "User",
-		BirthDate:        time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
-		Gender:           string(types.GenderMale),
-		SexPref:          string(types.SexPrefBoth),
-		RelationshipType: "long_term",
+		Username:     "loginuser",
+		Email:        "login@example.com",
+		PasswordHash: "$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi", // "password"
+		FirstName:    "Login",
+		LastName:     "User",
 	}
 	db.DB.Create(&user)
 
@@ -545,10 +540,6 @@ func TestForgotPasswordHandler(t *testing.T) {
 					LastName:     "User",
 					Email:        tt.payload["email"].(string),
 					PasswordHash: "$2a$10$abcdefg", // dummy hash
-					BirthDate:    time.Now().AddDate(-25, 0, 0),
-					Gender:       "male",
-					SexPref:      "both",
-					RelationshipType: "serious",
 				}
 				db.DB.Create(&user)
 				defer db.DB.Delete(&user)
@@ -586,14 +577,10 @@ func TestResetPasswordHandler(t *testing.T) {
 	// Setup test user
 	user := models.Users{
 		Username:     "testuser",
-		FirstName:    "Test", 
+		FirstName:    "Test",
 		LastName:     "User",
 		Email:        "test@example.com",
 		PasswordHash: "$2a$10$abcdefg", // dummy hash
-		BirthDate:    time.Now().AddDate(-25, 0, 0),
-		Gender:       "male",
-		SexPref:      "both",
-		RelationshipType: "serious",
 	}
 	db.DB.Create(&user)
 	defer db.DB.Delete(&user)

--- a/api/auth-service/templates/email/password_reset.html
+++ b/api/auth-service/templates/email/password_reset.html
@@ -2,38 +2,38 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Réinitialisation mot de passe</title>
+    <title>Réinitialisation mot de passe - Hypertube</title>
 </head>
 <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; text-align: center; border-radius: 10px;">
-        <h1 style="color: white; margin: 0;">💖 Matcha</h1>
-        <p style="color: white; margin: 10px 0 0 0;">Réinitialisation de mot de passe</p>
+    <div style="background: linear-gradient(135deg, #e50914 0%, #b20710 100%); padding: 30px; text-align: center; border-radius: 10px;">
+        <h1 style="color: white; margin: 0; font-size: 28px; letter-spacing: 2px;">HYPERTUBE</h1>
+        <p style="color: rgba(255,255,255,0.85); margin: 10px 0 0 0;">Réinitialisation de mot de passe</p>
     </div>
-    
+
     <div style="padding: 30px; background: #f8f9fa; border-radius: 0 0 10px 10px;">
         <h2 style="color: #333; margin-top: 0;">Réinitialiser votre mot de passe</h2>
         <p style="color: #666; line-height: 1.6;">
             Vous avez demandé une réinitialisation de mot de passe. Cliquez sur le bouton ci-dessous pour créer un nouveau mot de passe :
         </p>
-        
+
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{{.ResetURL}}" style="display: inline-block; padding: 15px 30px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 12px; font-weight: bold; font-size: 16px; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);">
-                🔑 Réinitialiser mon mot de passe
+            <a href="{{.ResetURL}}" style="display: inline-block; padding: 15px 30px; background: linear-gradient(135deg, #e50914 0%, #b20710 100%); color: white; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 16px; box-shadow: 0 4px 12px rgba(229, 9, 20, 0.3);">
+                Réinitialiser mon mot de passe
             </a>
         </div>
-        
+
         <p style="color: #666; line-height: 1.6;">
             Ce lien est valide pendant <strong>1 heure</strong>. Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer cet email.
         </p>
-        
+
         <p style="color: #888; font-size: 14px; line-height: 1.6;">
-            Si le bouton ne fonctionne pas, vous pouvez copier et coller ce lien dans votre navigateur :<br>
+            Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :<br>
             <span style="word-break: break-all; background: #f0f0f0; padding: 4px 8px; border-radius: 4px; font-family: monospace;">{{.ResetURL}}</span>
         </p>
-        
+
         <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #ddd;">
             <p style="color: #999; font-size: 14px; text-align: center; margin: 0;">
-                Cet email a été envoyé par Matcha. Si vous avez des questions, contactez notre support.
+                Cet email a été envoyé par Hypertube. Si vous avez des questions, contactez notre support.
             </p>
         </div>
     </div>

--- a/api/auth-service/templates/email/verification_email.html
+++ b/api/auth-service/templates/email/verification_email.html
@@ -2,34 +2,34 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Vérification Email</title>
+    <title>Vérification Email - Hypertube</title>
 </head>
 <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; text-align: center; border-radius: 10px;">
-        <h1 style="color: white; margin: 0;">💖 Matcha</h1>
-        <p style="color: white; margin: 10px 0 0 0;">Vérification de votre compte</p>
+    <div style="background: linear-gradient(135deg, #e50914 0%, #b20710 100%); padding: 30px; text-align: center; border-radius: 10px;">
+        <h1 style="color: white; margin: 0; font-size: 28px; letter-spacing: 2px;">HYPERTUBE</h1>
+        <p style="color: rgba(255,255,255,0.85); margin: 10px 0 0 0;">Vérification de votre compte</p>
     </div>
-    
+
     <div style="padding: 30px; background: #f8f9fa; border-radius: 0 0 10px 10px;">
         <h2 style="color: #333; margin-top: 0;">Vérifiez votre email</h2>
         <p style="color: #666; line-height: 1.6;">
-            Bienvenue sur Matcha ! Pour finaliser votre inscription, veuillez utiliser le code de vérification suivant :
+            Bienvenue sur Hypertube ! Pour finaliser votre inscription, utilisez le code de vérification suivant :
         </p>
-        
-        <div style="background: white; border: 2px solid #667eea; border-radius: 8px; padding: 20px; text-align: center; margin: 20px 0;">
-            <h3 style="margin: 0; color: #667eea;">Code de vérification</h3>
+
+        <div style="background: white; border: 2px solid #e50914; border-radius: 8px; padding: 20px; text-align: center; margin: 20px 0;">
+            <h3 style="margin: 0; color: #e50914;">Code de vérification</h3>
             <div style="font-size: 32px; font-weight: bold; color: #333; letter-spacing: 8px; margin: 10px 0;">
                 {{.VerificationCode}}
             </div>
         </div>
-        
+
         <p style="color: #666; line-height: 1.6;">
             Ce code est valide pendant <strong>15 minutes</strong>. Si vous n'avez pas demandé cette vérification, vous pouvez ignorer cet email.
         </p>
-        
+
         <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #ddd;">
             <p style="color: #999; font-size: 14px; text-align: center; margin: 0;">
-                Cet email a été envoyé par Matcha. Si vous avez des questions, contactez notre support.
+                Cet email a été envoyé par Hypertube. Si vous avez des questions, contactez notre support.
             </p>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- `POST /auth/forgot-password` — génère un token sécurisé (32 bytes hex), valable 1 heure, usage unique, et envoie un email avec le lien de réinitialisation
- `POST /auth/reset-password` — valide le token (non utilisé + non expiré), hache le nouveau mot de passe avec bcrypt, marque le token comme utilisé
- Templates email mis à jour avec le branding Hypertube (remplacement de l'ancien branding Matcha)
- Tests corrigés pour correspondre au modèle `Users` actuel

## Test plan

- [ ] `POST /auth/forgot-password` avec un email existant → retourne 200 et envoie le lien (affiché en console si SMTP non configuré)
- [ ] `POST /auth/forgot-password` avec un email inexistant → retourne 200 (sécurité : ne révèle pas l'existence du compte)
- [ ] `POST /auth/reset-password` avec un token valide et nouveau mot de passe → retourne 200, mot de passe mis à jour, token marqué comme utilisé
- [ ] `POST /auth/reset-password` avec un token expiré → retourne 400
- [ ] `POST /auth/reset-password` avec un token déjà utilisé → retourne 400
- [ ] `POST /auth/reset-password` avec le même mot de passe qu'avant → retourne 400
- [ ] `go test ./src/...` passe sans erreur

Closes #8