### PR TITLE
feat(torrent-service): streaming HTTP byte-range depuis fichier torrent

### DIFF
--- a/api/torrent-service/README.md
+++ b/api/torrent-service/README.md
@@ -131,7 +131,7 @@ GET /stream/:id
     └─ GetTorrentReader()
           ├─ torrent actif  → file.NewReader() (bloque sur morceaux manquants)
           └─ torrent terminé → os.Open(file_path)
-                └─ http.ServeContent() — gère Range/206 automatiquement
+          └─ http.ServeContent() — gère Range/206 automatiquement (les deux chemins)
 ```
 
 Le client `anacrolix/torrent` est un singleton partagé entre tous les téléchargements. Au démarrage, `reattachPendingTorrents()` recharge automatiquement les torrents dont le statut est `pending` ou `downloading`.
@@ -166,7 +166,6 @@ src/
 |----------|--------|-------------|
 | `PORT` | `8004` | Port d'écoute |
 | `TORRENT_DOWNLOAD_PATH` | `/data/torrents` | Répertoire de stockage des fichiers |
-| `STREAM_BUFFER_SIZE` | — | Taille du buffer de stream (MiB, non utilisé directement) |
 | `DB_HOST` | `localhost` | Hôte PostgreSQL |
 | `DB_PORT` | `5432` | Port PostgreSQL |
 | `DB_NAME` | `hypertube` | Nom de la base |
@@ -184,7 +183,7 @@ Les tests utilisent SQLite en mémoire (`github.com/glebarez/sqlite`, pur Go) po
 | Package | Tests |
 |---------|-------|
 | `services` | `extractInfoHash`, `findOrCreateRecord`, `GetRecord`, `StartDownload` |
-| `handlers` | health check, download (validation + erreurs), status (tous statuts), stream (pending/error/fichier manquant) |
+| `handlers` | health check, download (validation + erreurs), status (tous statuts), stream (pending/error/fichier manquant/succès/Range 206/MIME types) |
 
 ## Gestion des erreurs
 

--- a/api/torrent-service/src/handlers/handlers_test.go
+++ b/api/torrent-service/src/handlers/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -257,4 +258,91 @@ func TestStreamHandler_Ready_FileMissing(t *testing.T) {
 	r := newRouter()
 	w := get(r, "/api/v1/stream/"+validInfoHash)
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// makeTempVideoFile creates a temp file with the given extension and content,
+// registers a StatusReady DB record for it, and returns the file path.
+func makeTempVideoFile(t *testing.T, ext string, content []byte) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "testvideo*"+ext)
+	require.NoError(t, err)
+	_, err = f.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestStreamHandler_Ready_Success(t *testing.T) {
+	setupTestDB(t)
+	content := bytes.Repeat([]byte("A"), 100)
+	path := makeTempVideoFile(t, ".mp4", content)
+	conf.DB.Create(&models.TorrentRecord{
+		InfoHash:  validInfoHash,
+		MagnetURI: validMagnet,
+		MovieID:   1,
+		Status:    models.StatusReady,
+		FilePath:  path,
+		FileSize:  int64(len(content)),
+	})
+	r := newRouter()
+	w := get(r, "/api/v1/stream/"+validInfoHash)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+	assert.Equal(t, len(content), w.Body.Len())
+}
+
+func TestStreamHandler_Range_PartialContent(t *testing.T) {
+	setupTestDB(t)
+	content := make([]byte, 100)
+	for i := range content {
+		content[i] = byte(i)
+	}
+	path := makeTempVideoFile(t, ".mp4", content)
+	conf.DB.Create(&models.TorrentRecord{
+		InfoHash:  validInfoHash,
+		MagnetURI: validMagnet,
+		MovieID:   1,
+		Status:    models.StatusReady,
+		FilePath:  path,
+		FileSize:  int64(len(content)),
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/stream/"+validInfoHash, nil)
+	req.Header.Set("Range", "bytes=0-9")
+	w := httptest.NewRecorder()
+	newRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 0-9/100", w.Header().Get("Content-Range"))
+	assert.Equal(t, 10, w.Body.Len())
+	assert.Equal(t, content[:10], w.Body.Bytes())
+}
+
+func TestStreamHandler_MimeType(t *testing.T) {
+	tests := []struct {
+		ext      string
+		wantMime string
+	}{
+		{".mp4", "video/mp4"},
+		{".webm", "video/webm"},
+		{".mkv", "video/x-matroska"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			setupTestDB(t)
+			path := makeTempVideoFile(t, tt.ext, bytes.Repeat([]byte("B"), 20))
+			conf.DB.Create(&models.TorrentRecord{
+				InfoHash:  validInfoHash,
+				MagnetURI: validMagnet,
+				MovieID:   1,
+				Status:    models.StatusReady,
+				FilePath:  path,
+				FileSize:  20,
+			})
+			r := newRouter()
+			w := get(r, "/api/v1/stream/"+validInfoHash)
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Header().Get("Content-Type"), tt.wantMime)
+		})
+	}
 }

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +12,16 @@ import (
 	"torrent-service/src/services"
 	"torrent-service/src/utils"
 )
+
+func init() {
+	mime.AddExtensionType(".mkv", "video/x-matroska")
+	mime.AddExtensionType(".webm", "video/webm")
+	mime.AddExtensionType(".mp4", "video/mp4")
+	mime.AddExtensionType(".avi", "video/x-msvideo")
+	mime.AddExtensionType(".mov", "video/quicktime")
+	mime.AddExtensionType(".ogg", "video/ogg")
+	mime.AddExtensionType(".m4v", "video/mp4")
+}
 
 func StreamHandler(c *gin.Context) {
 	hash := c.Param("id")
@@ -43,12 +52,6 @@ func StreamHandler(c *gin.Context) {
 		return
 	}
 
-	contentType := mime.TypeByExtension(filepath.Ext(result.FileName))
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
-	c.Header("Content-Type", contentType)
 	c.Header("Accept-Ranges", "bytes")
 	if result.Size > 0 {
 		c.Header("X-Content-Length", fmt.Sprint(result.Size))


### PR DESCRIPTION
## Summary

- Enregistrement des MIME types vidéo communs (`mkv`, `webm`, `mp4`, `avi`, `mov`, `ogg`, `m4v`) via `mime.AddExtensionType` dans `stream.go` pour garantir un `Content-Type` correct sur tous les environnements Linux (la base de données MIME de l'OS ne connaît pas `.mkv` dans la plupart des conteneurs)
- Suppression du `Content-Type` positionné manuellement dans le handler — `http.ServeContent()` le gère déjà après l'enregistrement des types
- Ajout des tests manquants sur le chemin heureux : `TestStreamHandler_Ready_Success` (200 + `Accept-Ranges`), `TestStreamHandler_Range_PartialContent` (206 + `Content-Range`), `TestStreamHandler_MimeType` (`.mp4` / `.webm` / `.mkv`)
- Correction du README : diagramme d'architecture, suppression de la variable `STREAM_BUFFER_SIZE` inexistante, mise à jour de la couverture de tests

Closes #16

## Test plan

- [ ] `go test ./src/... -count=1` — tous les tests passent
- [ ] `curl -H "Range: bytes=0-1048575" http://localhost:8080/api/v1/stream/<hash>` → `HTTP/1.1 206`, `Content-Range: bytes 0-1048575/<total>`
- [ ] Lecteur HTML5 `<video>` dans Firefox et Chrome : seek fonctionnel, streaming démarre avant la fin du téléchargement