### PR TITLE
[Library] Recherche et pagination infinie de films

### DIFF
--- a/api/library-service/README.md
+++ b/api/library-service/README.md
@@ -4,6 +4,7 @@ Fournit les métadonnées films et les liens torrent pour Hypertube. Agrège tro
 
 ## Responsibilities
 
+- Catalogue films avec recherche, filtres et pagination infinie (cursor-based)
 - Recherche de films via TMDb ou OMDb (fallback)
 - Détail d'un film enrichi avec les torrents YTS
 - Recherche directe sur YTS (films disponibles en torrent avec seeds/peers)
@@ -14,9 +15,51 @@ Fournit les métadonnées films et les liens torrent pour Hypertube. Agrège tro
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/health` | — | Health check |
+| `GET` | `/api/v1/library/movies` | JWT | Films populaires / recherche avec filtres et pagination infinie |
 | `GET` | `/api/v1/library/movies/search` | JWT | Recherche TMDb / OMDb |
 | `GET` | `/api/v1/library/movies/yts` | JWT | Recherche YTS (avec torrents) |
 | `GET` | `/api/v1/library/movies/:id` | JWT | Détail d'un film (TMDb + torrents YTS) |
+
+---
+
+### GET /api/v1/library/movies
+
+Retourne les films populaires (triés par seeds par défaut) ou les résultats d'une recherche, avec pagination infinie par curseur.
+
+| Paramètre | Type | Requis | Description |
+|-----------|------|--------|-------------|
+| `q` | string | non | Terme de recherche (omis = films populaires) |
+| `genre` | string | non | Filtre par genre (ex : `Action`, `Comedy`) |
+| `rating` | float | non | Note minimale (ex : `7.0`) |
+| `year` | int | non | Filtre par année de sortie |
+| `sort_by` | string | non | Tri : `seeds` (défaut), `title`, `rating`, `year` |
+| `cursor` | string | non | Curseur de pagination (valeur `next_cursor` de la réponse précédente) |
+
+```json
+// 200 OK
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "id": 15442,
+        "imdb_id": "tt1375666",
+        "title": "Inception",
+        "year": "2010",
+        "rating": 8.8,
+        "poster_url": "https://yts.mx/assets/images/movies/...",
+        "genres": ["Action", "Sci-Fi"],
+        "watched": false,
+        "source": "yts"
+      }
+    ],
+    "next_cursor": "Mg==",
+    "total": 500
+  }
+}
+```
+
+Erreurs : `502` YTS injoignable
 
 ---
 
@@ -163,6 +206,7 @@ La logique de fallback pour la recherche : TMDb → OMDb (si TMDb KO). Pour le d
 
 | Clé | TTL | Contenu |
 |-----|-----|---------|
+| `movies:q:…:genre:…:page:{n}` | 1h | Résultats catalogue /movies |
 | `search:{q}:page:{n}` | 24h | Résultats de recherche TMDb/OMDb |
 | `movie:{tmdb_id}` | 24h | Détail film enrichi (métadonnées + torrents) |
 | `yts:search:{q}:page:{n}` | 1h | Résultats YTS (TTL court — seeds varient) |
@@ -189,18 +233,22 @@ Redis est optionnel : si indisponible au démarrage, le service fonctionne sans 
 ```
 src/
 ├── client/
-│   ├── tmdb.go     # Client HTTP TMDb (search + detail + credits)
-│   ├── omdb.go     # Client HTTP OMDb (search + title lookup)
-│   └── yts.go      # Client HTTP YTS (search + lookup par IMDb ID)
+│   ├── tmdb.go            # Client HTTP TMDb (search + detail + credits)
+│   ├── omdb.go            # Client HTTP OMDb (search + title lookup)
+│   └── yts.go             # Client HTTP YTS (List + search + lookup par IMDb ID)
 ├── conf/
-│   └── redis.go    # Connexion Redis + helpers GetCache/SetCache
+│   └── redis.go           # Connexion Redis + helpers GetCache/SetCache
 ├── handlers/
-│   └── movie.go    # Handlers Search, GetMovie, SearchYTS
+│   ├── handler.go         # Init handler + interfaces clients + helpers cache
+│   ├── movies.go          # Handler Movies (catalogue + pagination cursor)
+│   ├── search.go          # Handlers Search, SearchYTS
+│   ├── free.go            # Handler SearchFree (LegitTorrents + Archive.org)
+│   └── detail.go          # Handler GetMovie (TMDb + torrents YTS)
 ├── models/
-│   └── movie.go    # Movie, CastMember, Torrent, SearchResult
+│   └── movie.go           # Movie, CastMember, Torrent, SearchResult, CursorResult
 ├── utils/
-│   └── response.go # RespondSuccess / RespondError
-└── main.go         # Routes Gin + init Redis
+│   └── response.go        # RespondSuccess / RespondError
+└── main.go                # Routes Gin + init Redis
 ```
 
 ## Development

--- a/api/library-service/src/client/yts.go
+++ b/api/library-service/src/client/yts.go
@@ -83,15 +83,45 @@ type ytsTorrent struct {
 	Peers   int    `json:"peers"`
 }
 
+// ListParams holds optional filters and sort options for List.
+type ListParams struct {
+	Query     string
+	Genre     string
+	MinRating float64
+	Year      int    // filtered client-side (YTS has no year param)
+	SortBy    string // "seeds" | "title" | "year" | "rating"
+	Page      int
+}
+
 func (c *YTSClient) Search(query string, page int) (*models.SearchResult, error) {
-	if page < 1 {
-		page = 1
+	return c.List(ListParams{Query: query, Page: page, SortBy: "seeds"})
+}
+
+// List fetches movies from YTS with optional filters and sorting.
+func (c *YTSClient) List(p ListParams) (*models.SearchResult, error) {
+	if p.Page < 1 {
+		p.Page = 1
 	}
+
+	validSort := map[string]bool{"seeds": true, "title": true, "year": true, "rating": true, "download_count": true}
+	sortBy := "seeds"
+	if validSort[p.SortBy] {
+		sortBy = p.SortBy
+	}
+
 	params := url.Values{}
-	params.Set("query_term", query)
-	params.Set("page", strconv.Itoa(page))
+	if p.Query != "" {
+		params.Set("query_term", p.Query)
+	}
+	if p.Genre != "" {
+		params.Set("genre", p.Genre)
+	}
+	if p.MinRating > 0 {
+		params.Set("minimum_rating", strconv.FormatFloat(p.MinRating, 'f', 0, 64))
+	}
+	params.Set("sort_by", sortBy)
+	params.Set("page", strconv.Itoa(p.Page))
 	params.Set("limit", "20")
-	params.Set("sort_by", "seeds")
 
 	body, err := c.get(fmt.Sprintf("%s/list_movies.json?%s", ytsBaseURL, params.Encode()))
 	if err != nil {
@@ -112,11 +142,16 @@ func (c *YTSClient) Search(query string, page int) (*models.SearchResult, error)
 	}
 
 	result := &models.SearchResult{
-		Page:       page,
+		Page:       p.Page,
 		TotalPages: totalPages,
+		TotalCount: raw.Data.MovieCount,
 	}
 	for _, m := range raw.Data.Movies {
-		result.Results = append(result.Results, listMovieToModel(m))
+		movie := listMovieToModel(m)
+		if p.Year > 0 && m.Year != p.Year {
+			continue
+		}
+		result.Results = append(result.Results, movie)
 	}
 	return result, nil
 }

--- a/api/library-service/src/handlers/handler.go
+++ b/api/library-service/src/handlers/handler.go
@@ -14,6 +14,7 @@ import (
 	"library-service/src/utils"
 )
 
+
 const (
 	ytsCacheTTL  = 1 * time.Hour
 	freeCacheTTL = 2 * time.Hour
@@ -32,6 +33,7 @@ type searchClient interface {
 
 type ytsClient interface {
 	Search(query string, page int) (*models.SearchResult, error)
+	List(p client.ListParams) (*models.SearchResult, error)
 	GetMovieByIMDbID(imdbID string) (*models.Movie, error)
 }
 

--- a/api/library-service/src/handlers/movies.go
+++ b/api/library-service/src/handlers/movies.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"library-service/src/client"
+	"library-service/src/models"
+	"library-service/src/utils"
+)
+
+func (h *MovieHandler) Movies(c *gin.Context) {
+	query := c.Query("q")
+	genre := c.Query("genre")
+	ratingStr := c.Query("rating")
+	yearStr := c.Query("year")
+	sortBy := c.DefaultQuery("sort_by", "seeds")
+	cursor := c.Query("cursor")
+
+	page := decodeCursor(cursor)
+
+	var minRating float64
+	if ratingStr != "" {
+		minRating, _ = strconv.ParseFloat(ratingStr, 64)
+	}
+	var year int
+	if yearStr != "" {
+		year, _ = strconv.Atoi(yearStr)
+	}
+
+	cacheKey := fmt.Sprintf("movies:q:%s:genre:%s:rating:%.1f:year:%d:sort:%s:page:%d",
+		query, genre, minRating, year, sortBy, page)
+
+	var result models.CursorResult
+	if cacheGet(cacheKey, &result) {
+		utils.RespondSuccess(c, http.StatusOK, result)
+		return
+	}
+
+	params := client.ListParams{
+		Query:     query,
+		Genre:     genre,
+		MinRating: minRating,
+		Year:      year,
+		SortBy:    sortBy,
+		Page:      page,
+	}
+	searchResult, err := h.yts.List(params)
+	if err != nil {
+		utils.RespondError(c, http.StatusBadGateway, "failed to fetch movies")
+		return
+	}
+
+	result = models.CursorResult{
+		Results: searchResult.Results,
+		Total:   searchResult.TotalCount,
+	}
+	if page < searchResult.TotalPages {
+		result.NextCursor = encodeCursor(page + 1)
+	}
+
+	cacheSet(cacheKey, result, ytsCacheTTL)
+	utils.RespondSuccess(c, http.StatusOK, result)
+}
+
+func encodeCursor(page int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(page)))
+}
+
+func decodeCursor(s string) int {
+	if s == "" {
+		return 1
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return 1
+	}
+	page, _ := strconv.Atoi(string(b))
+	if page < 1 {
+		return 1
+	}
+	return page
+}

--- a/api/library-service/src/handlers/testhelpers_test.go
+++ b/api/library-service/src/handlers/testhelpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"library-service/src/client"
 	"library-service/src/models"
 )
 
@@ -58,6 +59,9 @@ type mockYTS struct {
 }
 
 func (m *mockYTS) Search(_ string, _ int) (*models.SearchResult, error) {
+	return m.searchResult, m.searchErr
+}
+func (m *mockYTS) List(_ client.ListParams) (*models.SearchResult, error) {
 	return m.searchResult, m.searchErr
 }
 func (m *mockYTS) GetMovieByIMDbID(_ string) (*models.Movie, error) {

--- a/api/library-service/src/main.go
+++ b/api/library-service/src/main.go
@@ -27,6 +27,7 @@ func main() {
 		{
 			movies := library.Group("/movies")
 			h := handlers.NewMovieHandler()
+			movies.GET("", h.Movies)
 			movies.GET("/search", h.Search)
 			movies.GET("/yts", h.SearchYTS)
 			movies.GET("/free", h.SearchFree)

--- a/api/library-service/src/models/movie.go
+++ b/api/library-service/src/models/movie.go
@@ -30,10 +30,18 @@ type Movie struct {
 	Cast        []CastMember `json:"cast"`
 	Torrents    []Torrent    `json:"torrents,omitempty"`
 	Source      string       `json:"source"`
+	Watched     bool         `json:"watched"`
 }
 
 type SearchResult struct {
 	Page       int     `json:"page"`
 	TotalPages int     `json:"total_pages"`
+	TotalCount int     `json:"total_count"`
 	Results    []Movie `json:"results"`
+}
+
+type CursorResult struct {
+	Results    []Movie `json:"results"`
+	NextCursor string  `json:"next_cursor,omitempty"`
+	Total      int     `json:"total"`
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/library/movies` endpoint serving popular movies (sorted by seeds) or search results
- Supports filtering by `genre`, `rating` (min), `year`, and sorting by `seeds`, `title`, `rating`, `year`
- Implements cursor-based pagination (`next_cursor`) for infinite scroll
- Extends YTS client with a `List(ListParams)` method covering all filter/sort options
- Adds `CursorResult` model and `watched` field on `Movie`
- Updates README with new endpoint docs, cache key, and layout

Closes #13

## Test plan

- [x] `GET /api/v1/library/movies` returns popular movies sorted by seeds with `next_cursor`
- [x] `GET /api/v1/library/movies?q=inception` returns search results
- [x] `GET /api/v1/library/movies?genre=Action&rating=7.0&year=2010` filters correctly
- [x] `GET /api/v1/library/movies?sort_by=rating` sorts by rating
- [x] Passing `cursor=<next_cursor>` loads the next page
- [x] Existing routes (`/movies/search`, `/movies/yts`, `/movies/:id`) still work
- [x] `go test ./...` passes