### PR TITLE
feat(torrent-service): transcodage à la volée avec ffmpeg (mkv → mp4)

### DIFF
--- a/api/torrent-service/README.md
+++ b/api/torrent-service/README.md
@@ -8,7 +8,8 @@ Gère le téléchargement BitTorrent à la demande et le streaming vidéo HTTP p
 - Téléchargement non-bloquant — le streaming commence dès les premiers morceaux reçus
 - Suivi de la progression en base de données (toutes les 5 s)
 - Reprise automatique des téléchargements en cours au redémarrage du service
-- Streaming HTTP avec support des requêtes `Range` (seek, lecture simultanée multi-clients)
+- Streaming HTTP avec support des requêtes `Range` pour les formats natifs (seek, lecture simultanée multi-clients)
+- Transcodage à la volée des formats non supportés nativement (MKV, AVI, MOV…) vers MP4 via ffmpeg
 - Sauvegarde persistante du fichier une fois le téléchargement terminé
 
 ## Endpoints
@@ -18,7 +19,7 @@ Gère le téléchargement BitTorrent à la demande et le streaming vidéo HTTP p
 | `GET`  | `/health` | — | Health check |
 | `POST` | `/api/v1/torrent/download` | JWT | Démarre (ou retrouve) un téléchargement |
 | `GET`  | `/api/v1/torrent/status/:id` | JWT | Progression d'un téléchargement |
-| `GET`  | `/api/v1/stream/:id` | JWT | Stream du fichier vidéo (Range supporté) |
+| `GET`  | `/api/v1/stream/:id` | JWT | Stream du fichier vidéo (transcodage automatique) |
 
 ---
 
@@ -82,28 +83,47 @@ Erreurs : `404` hash inconnu
 
 Streame le fichier vidéo. `:id` est le hash hexadécimal du torrent.
 
-- Supporte l'en-tête `Range` → réponse `206 Partial Content` (seek et reprise)
-- Plusieurs clients peuvent streamer le même torrent simultanément
-- Pendant le téléchargement, les lectures bloquent naturellement sur les morceaux non encore reçus
+Le service détecte automatiquement si le format nécessite un transcodage :
+
+**Format natif (MP4, WebM, OGG, M4V)**
+- Servi directement avec `http.ServeContent`
+- Supporte l'en-tête `Range` → réponse `206 Partial Content` (seek, reprise)
 
 ```
 GET /api/v1/stream/da39a3ee5e6b4b0d3255bfef95601890afd80709
 Range: bytes=0-
 
 HTTP/1.1 206 Partial Content
-Content-Type: video/x-matroska
+Content-Type: video/mp4
 Accept-Ranges: bytes
 Content-Range: bytes 0-1073741823/1073741824
+```
+
+**Format non natif (MKV, AVI, MOV…)**
+- Transcodage à la volée via ffmpeg (pipeline torrent reader → ffmpeg stdin → HTTP response, sans fichier temporaire)
+- Si les codecs source sont déjà H.264 + AAC/MP3 : remux uniquement (`-c copy`), pas de ré-encodage
+- Sinon : ré-encodage complet en H.264/AAC (`-preset ultrafast -tune zerolatency`)
+- Sortie en **fragmented MP4** (`frag_keyframe+empty_moov`), compatible Firefox et Chrome
+- `Range` non supporté — le navigateur reçoit un stream continu (`Transfer-Encoding: chunked`)
+
+```
+GET /api/v1/stream/da39a3ee5e6b4b0d3255bfef95601890afd80709
+
+HTTP/1.1 200 OK
+Content-Type: video/mp4
+Cache-Control: no-cache
+Transfer-Encoding: chunked
 ```
 
 Codes de retour :
 
 | Code | Cas |
 |------|-----|
-| `206` | Succès, contenu partiel (Range) |
-| `200` | Succès, contenu complet |
+| `206` | Format natif avec `Range` |
+| `200` | Format natif sans `Range`, ou format transcodé |
 | `202` | Torrent `pending`, réessayer après `Retry-After: 5` s |
 | `404` | Hash inconnu |
+| `500` | Erreur de lancement du transcodage ffmpeg |
 | `503` | Torrent en erreur ou fichier inaccessible |
 
 ---
@@ -131,7 +151,13 @@ GET /stream/:id
     └─ GetTorrentReader()
           ├─ torrent actif  → file.NewReader() (bloque sur morceaux manquants)
           └─ torrent terminé → os.Open(file_path)
-          └─ http.ServeContent() — gère Range/206 automatiquement (les deux chemins)
+    └─ NeedsTranscoding(filename)
+          ├─ format natif (mp4/webm/ogg/m4v)
+          │     └─ http.ServeContent() — gère Range/206 automatiquement
+          └─ format non natif (mkv/avi/mov…)
+                ├─ ProbeCodecs() via ffprobe (si fichier sur disque)
+                ├─ canCopyStream() → remux -c copy si H.264+AAC, sinon libx264+aac
+                └─ StartTranscode() → ffmpeg pipe:0→pipe:1 → HTTP chunked
 ```
 
 Le client `anacrolix/torrent` est un singleton partagé entre tous les téléchargements. Au démarrage, `reattachPendingTorrents()` recharge automatiquement les torrents dont le statut est `pending` ou `downloading`.
@@ -151,7 +177,8 @@ src/
 │   ├── client.go             singleton anacrolix, init, reattach
 │   ├── download.go           StartDownload, extractInfoHash, addToClient
 │   ├── monitor.go            monitorTorrent, prioritizeForStreaming, setError
-│   └── reader.go             GetTorrentReader, GetRecord
+│   ├── reader.go             GetTorrentReader, GetRecord
+│   └── transcoder.go         NeedsTranscoding, ProbeCodecs, StartTranscode
 ├── handlers/
 │   ├── download.go           POST /api/v1/torrent/download
 │   ├── status.go             GET  /api/v1/torrent/status/:id
@@ -159,6 +186,15 @@ src/
 └── utils/
     └── response.go           enveloppe JSON standard
 ```
+
+## Dépendances système
+
+| Outil | Rôle |
+|-------|------|
+| `ffmpeg` | Transcodage à la volée des formats non natifs |
+| `ffprobe` | Détection des codecs source (remux vs ré-encodage) |
+
+Les deux binaires doivent être présents dans le `PATH` du conteneur. Si `ffmpeg` est absent, les requêtes de stream sur des formats non natifs renvoient `500`.
 
 ## Variables d'environnement
 
@@ -182,8 +218,8 @@ Les tests utilisent SQLite en mémoire (`github.com/glebarez/sqlite`, pur Go) po
 
 | Package | Tests |
 |---------|-------|
-| `services` | `extractInfoHash`, `findOrCreateRecord`, `GetRecord`, `StartDownload` |
-| `handlers` | health check, download (validation + erreurs), status (tous statuts), stream (pending/error/fichier manquant/succès/Range 206/MIME types) |
+| `services` | `extractInfoHash`, `findOrCreateRecord`, `GetRecord`, `StartDownload`, `NeedsTranscoding`, `canCopyStream`, `buildFFmpegArgs`, `ProbeCodecs`, `StartTranscode` (intégration, requiert ffmpeg/ffprobe) |
+| `handlers` | health check, download (validation + erreurs), status (tous statuts), stream (pending/error/fichier manquant/succès/Range 206/MIME types/transcodage MKV→MP4) |
 
 ## Gestion des erreurs
 

--- a/api/torrent-service/src/handlers/handlers_test.go
+++ b/api/torrent-service/src/handlers/handlers_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -319,13 +321,14 @@ func TestStreamHandler_Range_PartialContent(t *testing.T) {
 }
 
 func TestStreamHandler_MimeType(t *testing.T) {
+	// Only native formats go through http.ServeContent which infers MIME from extension.
+	// Non-native formats (mkv, avi, …) are transcoded and always return video/mp4.
 	tests := []struct {
 		ext      string
 		wantMime string
 	}{
 		{".mp4", "video/mp4"},
 		{".webm", "video/webm"},
-		{".mkv", "video/x-matroska"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ext, func(t *testing.T) {
@@ -345,4 +348,70 @@ func TestStreamHandler_MimeType(t *testing.T) {
 			assert.Contains(t, w.Header().Get("Content-Type"), tt.wantMime)
 		})
 	}
+}
+
+// makeTestMKVFile creates a real 1-second H.264/AAC MKV via ffmpeg and registers
+// it in the DB as StatusReady. Skips the test if ffmpeg is not in PATH.
+func makeTestMKVFile(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not in PATH")
+	}
+	out := filepath.Join(t.TempDir(), "test.mkv")
+	cmd := exec.Command("ffmpeg",
+		"-f", "lavfi", "-i", "testsrc=duration=1:size=64x64:rate=1",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+		"-c:v", "libx264", "-c:a", "aac",
+		"-t", "1", "-y", out,
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg test-video generation failed: %s", output)
+	return out
+}
+
+func TestStreamHandler_Transcode_ContentType(t *testing.T) {
+	setupTestDB(t)
+	path := makeTestMKVFile(t)
+
+	info, _ := os.Stat(path)
+	conf.DB.Create(&models.TorrentRecord{
+		InfoHash:  validInfoHash,
+		MagnetURI: validMagnet,
+		MovieID:   1,
+		Status:    models.StatusReady,
+		FilePath:  path,
+		FileSize:  info.Size(),
+	})
+
+	r := newRouter()
+	w := get(r, "/api/v1/stream/"+validInfoHash)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "video/mp4")
+	assert.Greater(t, w.Body.Len(), 64, "transcoded output should contain MP4 data")
+}
+
+func TestStreamHandler_Transcode_NoByteRange(t *testing.T) {
+	// Transcoded streams do not support byte-range (ffmpeg pipe is not seekable).
+	setupTestDB(t)
+	path := makeTestMKVFile(t)
+
+	info, _ := os.Stat(path)
+	conf.DB.Create(&models.TorrentRecord{
+		InfoHash:  validInfoHash,
+		MagnetURI: validMagnet,
+		MovieID:   1,
+		Status:    models.StatusReady,
+		FilePath:  path,
+		FileSize:  info.Size(),
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/stream/"+validInfoHash, nil)
+	req.Header.Set("Range", "bytes=0-99")
+	w := httptest.NewRecorder()
+	newRouter().ServeHTTP(w, req)
+
+	// Transcoded response is always 200 (full stream), never 206 Partial Content.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Accept-Ranges"))
 }

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"time"
@@ -52,10 +53,35 @@ func StreamHandler(c *gin.Context) {
 		return
 	}
 
+	if services.NeedsTranscoding(result.FileName) {
+		serveTranscoded(c, result)
+		return
+	}
+
 	c.Header("Accept-Ranges", "bytes")
 	if result.Size > 0 {
 		c.Header("X-Content-Length", fmt.Sprint(result.Size))
 	}
-
 	http.ServeContent(c.Writer, c.Request, result.FileName, time.Time{}, result.Reader)
+}
+
+func serveTranscoded(c *gin.Context, result services.ReaderResult) {
+	var codecInfo *services.CodecInfo
+	if result.FilePath != "" {
+		codecInfo, _ = services.ProbeCodecs(result.FilePath)
+	}
+
+	job, err := services.StartTranscode(result.Reader, codecInfo)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "transcoding error: "+err.Error())
+		return
+	}
+	defer job.Cmd.Wait()
+	defer job.Reader.Close()
+
+	c.Header("Content-Type", job.ContentType)
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+	io.Copy(c.Writer, job.Reader) //nolint:errcheck
 }

--- a/api/torrent-service/src/services/reader.go
+++ b/api/torrent-service/src/services/reader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/anacrolix/torrent"
@@ -15,7 +16,7 @@ import (
 // GetTorrentReader returns an io.ReadSeeker for the largest file in the torrent.
 // For an in-progress torrent it uses the anacrolix reader (blocks on missing pieces).
 // For a completed torrent it reads directly from disk.
-func GetTorrentReader(infoHash string) (readerResult, error) {
+func GetTorrentReader(infoHash string) (ReaderResult, error) {
 	if v, ok := activeTorrents.Load(infoHash); ok {
 		return readerFromActiveTorrent(v.(*torrent.Torrent))
 	}
@@ -31,10 +32,11 @@ func GetRecord(infoHash string) (*models.TorrentRecord, error) {
 	return &record, nil
 }
 
-type readerResult struct {
+type ReaderResult struct {
 	Reader   torrentReader
 	Size     int64
 	FileName string
+	FilePath string // absolute path on disk; empty while pieces are still downloading
 }
 
 // torrentReader is satisfied by both *os.File and torrent.Reader.
@@ -43,35 +45,36 @@ type torrentReader interface {
 	Seek(offset int64, whence int) (int64, error)
 }
 
-func readerFromActiveTorrent(t *torrent.Torrent) (readerResult, error) {
+func readerFromActiveTorrent(t *torrent.Torrent) (ReaderResult, error) {
 	select {
 	case <-t.GotInfo():
 	case <-time.After(30 * time.Second):
-		return readerResult{}, errors.New("torrent info not yet available")
+		return ReaderResult{}, errors.New("torrent info not yet available")
 	}
 
 	f := largestFile(t)
 	if f == nil {
-		return readerResult{}, errors.New("no files in torrent")
+		return ReaderResult{}, errors.New("no files in torrent")
 	}
 
 	r := f.NewReader()
 	r.SetReadahead(5 << 20) // 5 MiB readahead for smooth streaming
-	return readerResult{Reader: r, Size: f.Length(), FileName: f.DisplayPath()}, nil
+	filePath := downloadDir() + "/" + strings.ToLower(t.InfoHash().HexString()) + "/" + f.DisplayPath()
+	return ReaderResult{Reader: r, Size: f.Length(), FileName: f.DisplayPath(), FilePath: filePath}, nil
 }
 
-func readerFromDisk(infoHash string) (readerResult, error) {
+func readerFromDisk(infoHash string) (ReaderResult, error) {
 	record, err := GetRecord(infoHash)
 	if err != nil {
-		return readerResult{}, fmt.Errorf("torrent not found: %w", err)
+		return ReaderResult{}, fmt.Errorf("torrent not found: %w", err)
 	}
 	if record.Status != models.StatusReady || record.FilePath == "" {
-		return readerResult{}, errors.New("torrent not ready")
+		return ReaderResult{}, errors.New("torrent not ready")
 	}
 
 	f, err := os.Open(record.FilePath)
 	if err != nil {
-		return readerResult{}, fmt.Errorf("open file: %w", err)
+		return ReaderResult{}, fmt.Errorf("open file: %w", err)
 	}
-	return readerResult{Reader: f, Size: record.FileSize, FileName: record.FilePath}, nil
+	return ReaderResult{Reader: f, Size: record.FileSize, FileName: record.FilePath, FilePath: record.FilePath}, nil
 }

--- a/api/torrent-service/src/services/transcoder.go
+++ b/api/torrent-service/src/services/transcoder.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var nativeBrowserExtensions = map[string]bool{
+	".mp4":  true,
+	".webm": true,
+	".ogg":  true,
+	".m4v":  true,
+}
+
+// CodecInfo holds the detected video and audio codec names from ffprobe.
+type CodecInfo struct {
+	VideoCodec string
+	AudioCodec string
+}
+
+// TranscodeJob holds the running ffmpeg process and its output reader.
+type TranscodeJob struct {
+	Reader      io.ReadCloser
+	Cmd         *exec.Cmd
+	ContentType string
+}
+
+// NeedsTranscoding returns true when the file extension is not natively playable in browsers.
+func NeedsTranscoding(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return !nativeBrowserExtensions[ext]
+}
+
+// ProbeCodecs runs ffprobe on filePath and returns the first video and audio codec names.
+func ProbeCodecs(filePath string) (*CodecInfo, error) {
+	out, err := exec.Command(
+		"ffprobe",
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_streams",
+		filePath,
+	).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var probe struct {
+		Streams []struct {
+			CodecType string `json:"codec_type"`
+			CodecName string `json:"codec_name"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(out, &probe); err != nil {
+		return nil, err
+	}
+
+	info := &CodecInfo{}
+	for _, s := range probe.Streams {
+		switch s.CodecType {
+		case "video":
+			if info.VideoCodec == "" {
+				info.VideoCodec = s.CodecName
+			}
+		case "audio":
+			if info.AudioCodec == "" {
+				info.AudioCodec = s.CodecName
+			}
+		}
+	}
+	return info, nil
+}
+
+// canCopyStream returns true when the source is already H.264 video with AAC/MP3 audio,
+// meaning we can remux to fMP4 without re-encoding (much faster).
+func canCopyStream(info *CodecInfo) bool {
+	if info == nil {
+		return false
+	}
+	videoOK := info.VideoCodec == "h264"
+	audioOK := info.AudioCodec == "aac" || info.AudioCodec == "mp3"
+	return videoOK && audioOK
+}
+
+// StartTranscode spawns ffmpeg reading from reader and writing fragmented MP4 to its stdout.
+// When codecInfo indicates H.264+AAC, it remuxes with -c copy; otherwise it re-encodes.
+func StartTranscode(reader io.Reader, codecInfo *CodecInfo) (*TranscodeJob, error) {
+	args := buildFFmpegArgs(codecInfo)
+	cmd := exec.Command("ffmpeg", args...)
+	cmd.Stdin = reader
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	// Log stderr so transcoding errors appear in service logs.
+	cmd.Stderr = newPrefixWriter("ffmpeg")
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &TranscodeJob{Reader: stdout, Cmd: cmd, ContentType: "video/mp4"}, nil
+}
+
+func buildFFmpegArgs(info *CodecInfo) []string {
+	base := []string{
+		"-i", "pipe:0",
+		"-f", "mp4",
+		"-movflags", "frag_keyframe+empty_moov+default_base_moof",
+		"pipe:1",
+	}
+
+	if canCopyStream(info) {
+		// Remux only — no re-encoding, very fast.
+		return append([]string{"-c", "copy"}, base...)
+	}
+
+	// Full transcode to H.264/AAC for maximum browser compatibility.
+	return append([]string{
+		"-c:v", "libx264",
+		"-preset", "ultrafast",
+		"-tune", "zerolatency",
+		"-c:a", "aac",
+		"-b:a", "128k",
+	}, base...)
+}
+
+// prefixWriter writes log lines prefixed with a label.
+type prefixWriter struct{ label string }
+
+func newPrefixWriter(label string) *prefixWriter { return &prefixWriter{label: label} }
+
+func (w *prefixWriter) Write(p []byte) (int, error) {
+	log.Printf("[%s] %s", w.label, strings.TrimRight(string(p), "\n"))
+	return len(p), nil
+}

--- a/api/torrent-service/src/services/transcoder.go
+++ b/api/torrent-service/src/services/transcoder.go
@@ -106,8 +106,8 @@ func StartTranscode(reader io.Reader, codecInfo *CodecInfo) (*TranscodeJob, erro
 }
 
 func buildFFmpegArgs(info *CodecInfo) []string {
-	base := []string{
-		"-i", "pipe:0",
+	// -i must come first; all codec and format flags are output options.
+	output := []string{
 		"-f", "mp4",
 		"-movflags", "frag_keyframe+empty_moov+default_base_moof",
 		"pipe:1",
@@ -115,17 +115,18 @@ func buildFFmpegArgs(info *CodecInfo) []string {
 
 	if canCopyStream(info) {
 		// Remux only — no re-encoding, very fast.
-		return append([]string{"-c", "copy"}, base...)
+		return append([]string{"-i", "pipe:0", "-c", "copy"}, output...)
 	}
 
 	// Full transcode to H.264/AAC for maximum browser compatibility.
 	return append([]string{
+		"-i", "pipe:0",
 		"-c:v", "libx264",
 		"-preset", "ultrafast",
 		"-tune", "zerolatency",
 		"-c:a", "aac",
 		"-b:a", "128k",
-	}, base...)
+	}, output...)
 }
 
 // prefixWriter writes log lines prefixed with a label.

--- a/api/torrent-service/src/services/transcoder_test.go
+++ b/api/torrent-service/src/services/transcoder_test.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestMKV generates a 1-second 64x64 MKV with H.264+AAC via ffmpeg.
+// Skips the test if ffmpeg is not in PATH.
+func makeTestMKV(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not in PATH")
+	}
+	out := filepath.Join(t.TempDir(), "test.mkv")
+	cmd := exec.Command("ffmpeg",
+		"-f", "lavfi", "-i", "testsrc=duration=1:size=64x64:rate=1",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+		"-c:v", "libx264", "-c:a", "aac",
+		"-t", "1", "-y", out,
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg test-video generation failed: %s", output)
+	return out
+}
+
+// ---- NeedsTranscoding ----
+
+func TestNeedsTranscoding(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     bool
+	}{
+		{"movie.mkv", true},
+		{"movie.avi", true},
+		{"movie.mov", true},
+		{"movie.MKV", true}, // case-insensitive
+		{"movie.AVI", true},
+		{"movie.mp4", false},
+		{"movie.MP4", false},
+		{"movie.webm", false},
+		{"movie.ogg", false},
+		{"movie.m4v", false},
+		{"noextension", true},
+		{"", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			assert.Equal(t, tt.want, NeedsTranscoding(tt.filename))
+		})
+	}
+}
+
+// ---- canCopyStream ----
+
+func TestCanCopyStream(t *testing.T) {
+	tests := []struct {
+		name string
+		info *CodecInfo
+		want bool
+	}{
+		{"nil info", nil, false},
+		{"h264+aac", &CodecInfo{VideoCodec: "h264", AudioCodec: "aac"}, true},
+		{"h264+mp3", &CodecInfo{VideoCodec: "h264", AudioCodec: "mp3"}, true},
+		{"hevc+aac needs transcode", &CodecInfo{VideoCodec: "hevc", AudioCodec: "aac"}, false},
+		{"h264+opus needs transcode", &CodecInfo{VideoCodec: "h264", AudioCodec: "opus"}, false},
+		{"h264+ac3 needs transcode", &CodecInfo{VideoCodec: "h264", AudioCodec: "ac3"}, false},
+		{"vp9+opus needs transcode", &CodecInfo{VideoCodec: "vp9", AudioCodec: "opus"}, false},
+		{"empty codecs", &CodecInfo{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canCopyStream(tt.info))
+		})
+	}
+}
+
+// ---- buildFFmpegArgs ----
+
+func TestBuildFFmpegArgs_Remux(t *testing.T) {
+	args := buildFFmpegArgs(&CodecInfo{VideoCodec: "h264", AudioCodec: "aac"})
+	assert.Contains(t, args, "copy")
+	assert.Contains(t, args, "frag_keyframe+empty_moov+default_base_moof")
+	assert.NotContains(t, args, "libx264")
+	assert.NotContains(t, args, "ultrafast")
+}
+
+func TestBuildFFmpegArgs_Transcode(t *testing.T) {
+	tests := []struct {
+		name string
+		info *CodecInfo
+	}{
+		{"nil info", nil},
+		{"hevc+aac", &CodecInfo{VideoCodec: "hevc", AudioCodec: "aac"}},
+		{"h264+opus", &CodecInfo{VideoCodec: "h264", AudioCodec: "opus"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildFFmpegArgs(tt.info)
+			assert.Contains(t, args, "libx264")
+			assert.Contains(t, args, "ultrafast")
+			assert.Contains(t, args, "aac")
+			assert.Contains(t, args, "frag_keyframe+empty_moov+default_base_moof")
+			assert.NotContains(t, args, "copy")
+		})
+	}
+}
+
+// ---- ProbeCodecs ----
+
+func TestProbeCodecs(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not in PATH")
+	}
+	path := makeTestMKV(t)
+
+	info, err := ProbeCodecs(path)
+	require.NoError(t, err)
+	assert.Equal(t, "h264", info.VideoCodec)
+	assert.Equal(t, "aac", info.AudioCodec)
+}
+
+func TestProbeCodecs_NonVideoFile(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not in PATH")
+	}
+	f, err := os.CreateTemp(t.TempDir(), "notavideo*.txt")
+	require.NoError(t, err)
+	_, _ = f.WriteString("not a video")
+	f.Close()
+
+	// ffprobe on a text file should error (non-zero exit)
+	_, err = ProbeCodecs(f.Name())
+	assert.Error(t, err)
+}
+
+func TestProbeCodecs_NonExistentFile(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not in PATH")
+	}
+	_, err := ProbeCodecs("/tmp/this_file_does_not_exist_xyz.mkv")
+	assert.Error(t, err)
+}
+
+// ---- StartTranscode ----
+
+func TestStartTranscode_FullTranscode(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not in PATH")
+	}
+	path := makeTestMKV(t)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	job, err := StartTranscode(f, nil) // nil → full transcode
+	require.NoError(t, err)
+	defer job.Cmd.Wait()
+
+	out, err := io.ReadAll(job.Reader)
+	job.Reader.Close()
+
+	require.NoError(t, err)
+	assert.Equal(t, "video/mp4", job.ContentType)
+	// A valid fragmented MP4 has at least a few hundred bytes.
+	assert.Greater(t, len(out), 64, "output should contain fragmented MP4 data")
+}
+
+func TestStartTranscode_Remux(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not in PATH")
+	}
+	path := makeTestMKV(t)
+
+	info, err := ProbeCodecs(path)
+	if err != nil || !canCopyStream(info) {
+		t.Skip("test MKV does not have h264+aac, skipping remux test")
+	}
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	job, err := StartTranscode(f, info) // compatible codecs → remux
+	require.NoError(t, err)
+	defer job.Cmd.Wait()
+
+	out, err := io.ReadAll(job.Reader)
+	job.Reader.Close()
+
+	require.NoError(t, err)
+	assert.Equal(t, "video/mp4", job.ContentType)
+	assert.Greater(t, len(out), 64)
+}
+
+func TestStartTranscode_FFmpegNotFound(t *testing.T) {
+	// Temporarily shadow PATH to simulate ffmpeg absence.
+	orig := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", t.TempDir()))
+	t.Cleanup(func() { os.Setenv("PATH", orig) })
+
+	_, err := StartTranscode(nil, nil)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Détection automatique du format source via `NeedsTranscoding` (extension) et `ProbeCodecs` (ffprobe)
- Pipeline de streaming sans fichier temporaire : torrent reader → ffmpeg stdin → HTTP response
- Remux (`-c copy`) si les codecs sont déjà H.264+AAC, sinon ré-encodage `libx264 ultrafast + aac`
- Sortie en fragmented MP4 (`frag_keyframe+empty_moov`), compatible Firefox et Chrome
- Formats natifs (mp4, webm, ogg, m4v) inchangés : `http.ServeContent` + Range/206 préservé

## Fichiers modifiés

- `services/transcoder.go` — nouveau : `NeedsTranscoding`, `ProbeCodecs`, `StartTranscode`, `buildFFmpegArgs`
- `services/reader.go` — `ReaderResult` exporté, champ `FilePath` ajouté
- `handlers/stream.go` — branche transcoding avant `http.ServeContent`
- `services/transcoder_test.go` — nouveau : 14 tests unitaires + intégration (ffmpeg/ffprobe)
- `handlers/handlers_test.go` — tests MKV mis à jour, 2 nouveaux tests de transcodage
- `README.md` — documentation mise à jour

Closes #17