### PR TITLE
feat(#25): page détail film — player vidéo, commentaires et fixes backend

### DIFF
--- a/api/library-service/src/client/yts.go
+++ b/api/library-service/src/client/yts.go
@@ -156,6 +156,30 @@ func (c *YTSClient) List(p ListParams) (*models.SearchResult, error) {
 	return result, nil
 }
 
+func (c *YTSClient) GetMovieByID(id int) (*models.Movie, error) {
+	params := url.Values{}
+	params.Set("movie_id", strconv.Itoa(id))
+	params.Set("with_images", "true")
+
+	body, err := c.get(fmt.Sprintf("%s/movie_details.json?%s", ytsBaseURL, params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	var raw detailResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	if raw.Status != "ok" {
+		return nil, fmt.Errorf("YTS error: %s", raw.Status)
+	}
+	if raw.Data.Movie.ID == 0 {
+		return nil, nil
+	}
+	m := detailMovieToModel(raw.Data.Movie)
+	return &m, nil
+}
+
 func (c *YTSClient) GetMovieByIMDbID(imdbID string) (*models.Movie, error) {
 	params := url.Values{}
 	params.Set("imdb_id", imdbID)

--- a/api/library-service/src/handlers/detail.go
+++ b/api/library-service/src/handlers/detail.go
@@ -41,25 +41,34 @@ func (h *MovieHandler) GetMovie(c *gin.Context) {
 	fromCache := cacheGet(cacheKey, &movie)
 
 	if !fromCache {
-		if !h.tmdb.Available() {
-			utils.RespondError(c, http.StatusServiceUnavailable, "no metadata provider available")
-			return
+		var result *models.Movie
+
+		if h.tmdb.Available() {
+			var err error
+			result, err = h.tmdb.GetMovie(id)
+			if err != nil {
+				utils.RespondError(c, http.StatusBadGateway, "failed to fetch movie details")
+				return
+			}
+			if result != nil && result.IMDbID != "" {
+				if ytsMovie, ytsErr := h.yts.GetMovieByIMDbID(result.IMDbID); ytsErr == nil && ytsMovie != nil {
+					result.Torrents = ytsMovie.Torrents
+				}
+			}
 		}
 
-		result, err := h.tmdb.GetMovie(id)
-		if err != nil {
-			utils.RespondError(c, http.StatusBadGateway, "failed to fetch movie details")
-			return
+		if result == nil {
+			var ytsErr error
+			result, ytsErr = h.yts.GetMovieByID(id)
+			if ytsErr != nil {
+				utils.RespondError(c, http.StatusBadGateway, "failed to fetch movie details")
+				return
+			}
 		}
+
 		if result == nil {
 			utils.RespondError(c, http.StatusNotFound, "movie not found")
 			return
-		}
-
-		if result.IMDbID != "" {
-			if ytsMovie, ytsErr := h.yts.GetMovieByIMDbID(result.IMDbID); ytsErr == nil && ytsMovie != nil {
-				result.Torrents = ytsMovie.Torrents
-			}
 		}
 
 		for i, t := range result.Torrents {

--- a/api/library-service/src/handlers/handler.go
+++ b/api/library-service/src/handlers/handler.go
@@ -34,6 +34,7 @@ type searchClient interface {
 type ytsClient interface {
 	Search(query string, page int) (*models.SearchResult, error)
 	List(p client.ListParams) (*models.SearchResult, error)
+	GetMovieByID(id int) (*models.Movie, error)
 	GetMovieByIMDbID(imdbID string) (*models.Movie, error)
 }
 

--- a/api/torrent-service/Dockerfile
+++ b/api/torrent-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26-alpine AS development
 WORKDIR /app
-RUN apk --no-cache add gcc musl-dev
+RUN apk --no-cache add gcc g++ musl-dev
 RUN go install github.com/air-verse/air@latest
 COPY go.mod go.sum ./
 RUN go mod download

--- a/api/torrent-service/src/services/download.go
+++ b/api/torrent-service/src/services/download.go
@@ -55,7 +55,24 @@ func StartDownload(magnetURI string, movieID int) (string, error) {
 	return infoHash, nil
 }
 
-func findOrCreateRecord(magnetURI, infoHash string, movieID int) (*models.TorrentRecord, error) {
+func resolveLocalMovieID(tmdbID int) (int, error) {
+	var localID int
+	conf.DB.Raw("SELECT id FROM movies WHERE tmdb_id = ?", tmdbID).Scan(&localID)
+	if localID > 0 {
+		return localID, nil
+	}
+	// Movie not yet cached by library-service — insert a minimal placeholder.
+	if err := conf.DB.Exec(
+		"INSERT INTO movies (tmdb_id, title) VALUES (?, ?) ON CONFLICT (tmdb_id) DO NOTHING",
+		tmdbID, fmt.Sprintf("movie:%d", tmdbID),
+	).Error; err != nil {
+		return 0, fmt.Errorf("placeholder movie insert: %w", err)
+	}
+	conf.DB.Raw("SELECT id FROM movies WHERE tmdb_id = ?", tmdbID).Scan(&localID)
+	return localID, nil
+}
+
+func findOrCreateRecord(magnetURI, infoHash string, tmdbID int) (*models.TorrentRecord, error) {
 	var record models.TorrentRecord
 	dbErr := conf.DB.Where("info_hash = ?", infoHash).First(&record).Error
 
@@ -76,8 +93,13 @@ func findOrCreateRecord(magnetURI, infoHash string, movieID int) (*models.Torren
 		return nil, fmt.Errorf("db lookup: %w", dbErr)
 	}
 
+	localMovieID, err := resolveLocalMovieID(tmdbID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve movie id: %w", err)
+	}
+
 	record = models.TorrentRecord{
-		MovieID:   movieID,
+		MovieID:   localMovieID,
 		MagnetURI: magnetURI,
 		InfoHash:  infoHash,
 		Status:    models.StatusPending,

--- a/frontend/src/app/(main)/movies/[id]/page.tsx
+++ b/frontend/src/app/(main)/movies/[id]/page.tsx
@@ -1,0 +1,185 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { getAccessToken } from '@/lib/session'
+import { MoviePlayer } from '@/components/page/MoviePlayer'
+import { CommentSection } from '@/components/page/CommentSection'
+import type { Metadata } from 'next'
+
+interface CastMember {
+  name: string
+  character: string
+  order: number
+}
+
+interface Torrent {
+  url: string
+  hash: string
+  quality: string
+  type: string
+  size: string
+  seeds: number
+  peers: number
+  magnet: string
+}
+
+interface Comment {
+  id: number
+  user_id: number
+  username: string
+  avatar_url: string
+  content: string
+  created_at: string
+}
+
+export interface MovieDetail {
+  id: number
+  imdb_id: string
+  title: string
+  year: string
+  release_date: string
+  overview: string
+  runtime: number
+  rating: number
+  poster_url: string
+  backdrop_url: string
+  genres: string[]
+  cast: CastMember[]
+  torrents: Torrent[]
+  comments: Comment[]
+  watched: boolean
+}
+
+async function getMovie(id: string): Promise<MovieDetail | null> {
+  const token = await getAccessToken()
+  try {
+    const res = await fetch(`${process.env.API_URL ?? 'http://caddy'}/api/v1/library/movies/${id}`, {
+      headers: { Authorization: `Bearer ${token ?? ''}` },
+      next: { revalidate: 300 },
+    })
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`API error ${res.status}`)
+    const json = await res.json()
+    return json.data ?? json
+  } catch {
+    return null
+  }
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params
+  const movie = await getMovie(id)
+  if (!movie) return { title: 'Film introuvable — Hypertube' }
+  return { title: `${movie.title} (${movie.year}) — Hypertube` }
+}
+
+function formatRuntime(minutes: number): string {
+  if (!minutes) return ''
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return h > 0 ? `${h}h ${m.toString().padStart(2, '0')}m` : `${m}m`
+}
+
+export default async function MovieDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const movie = await getMovie(id)
+  if (!movie) notFound()
+
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-5xl mx-auto px-4 pt-4">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="size-4" />
+          Retour
+        </Link>
+      </div>
+
+      {movie.backdrop_url && (
+        <div className="relative w-full h-56 sm:h-72 md:h-96 overflow-hidden">
+          <img
+            src={movie.backdrop_url}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent" />
+        </div>
+      )}
+
+      <div className="max-w-5xl mx-auto px-4 pb-16">
+        <div className={`flex gap-6 ${movie.backdrop_url ? '-mt-24 relative z-10' : 'mt-8'}`}>
+          {movie.poster_url && (
+            <div className="hidden sm:block shrink-0 w-36 md:w-48">
+              <img
+                src={movie.poster_url}
+                alt={movie.title}
+                className="w-full rounded-lg shadow-lg border border-border"
+              />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 justify-end min-w-0">
+            <h1 className="text-2xl md:text-4xl font-bold leading-tight">{movie.title}</h1>
+
+            <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+              {movie.year && <span>{movie.year}</span>}
+              {movie.runtime > 0 && <span>{formatRuntime(movie.runtime)}</span>}
+              {movie.rating > 0 && (
+                <span className="text-destructive font-semibold">⭐ {movie.rating.toFixed(1)}</span>
+              )}
+            </div>
+
+            {(movie.genres?.length ?? 0) > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {movie.genres.map(genre => (
+                  <span
+                    key={genre}
+                    className="text-xs px-2 py-0.5 rounded-full border border-border bg-muted text-muted-foreground"
+                  >
+                    {genre}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {movie.overview && (
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">{movie.overview}</p>
+            )}
+          </div>
+        </div>
+
+        {(movie.cast?.length ?? 0) > 0 && (
+          <section className="mt-10">
+            <h2 className="text-lg font-semibold mb-3">Casting</h2>
+            <div className="flex gap-3 overflow-x-auto pb-2">
+              {movie.cast.slice(0, 12).map(member => (
+                <div
+                  key={`${member.name}-${member.order}`}
+                  className="shrink-0 w-24 text-center"
+                >
+                  <div className="w-16 h-16 rounded-full bg-muted mx-auto flex items-center justify-center overflow-hidden">
+                    <span className="text-xl font-bold text-muted-foreground">
+                      {member.name.charAt(0)}
+                    </span>
+                  </div>
+                  <p className="text-xs font-medium mt-2 truncate">{member.name}</p>
+                  <p className="text-xs text-muted-foreground truncate">{member.character}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="mt-10">
+          <MoviePlayer torrents={movie.torrents ?? []} movieId={movie.id} />
+        </section>
+
+        <section className="mt-12">
+          <CommentSection movieId={movie.id} initialComments={movie.comments ?? []} />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/page/CommentSection.tsx
+++ b/frontend/src/components/page/CommentSection.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Comment {
+  id: number
+  user_id: number
+  username: string
+  avatar_url: string
+  content: string
+  created_at: string
+}
+
+interface CommentSectionProps {
+  movieId: number
+  initialComments: Comment[]
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+export function CommentSection({ movieId, initialComments }: CommentSectionProps) {
+  const { t } = useTranslation()
+  const [comments, setComments] = useState<Comment[]>(initialComments)
+  const [content, setContent] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!content.trim()) return
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`/api/v1/comments/${movieId}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: content.trim() }),
+      })
+      if (!res.ok) throw new Error(`${res.status}`)
+      const json = await res.json()
+      const newComment: Comment = json.data ?? json
+      setComments(prev => [newComment, ...prev])
+      setContent('')
+    } catch {
+      setError(t('movie.comment_error'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (commentId: number) => {
+    try {
+      const res = await fetch(`/api/v1/comments/${commentId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (res.ok) {
+        setComments(prev => prev.filter(c => c.id !== commentId))
+      }
+    } catch {
+      // silently ignore
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-lg font-semibold">{t('movie.comments_title')}</h2>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder={t('movie.comment_placeholder')}
+          rows={3}
+          maxLength={2000}
+          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm resize-none focus:outline-none focus:ring-1 focus:ring-sidebar-primary"
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={submitting || !content.trim()}
+            className="px-4 py-1.5 rounded-md bg-sidebar-primary text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {submitting ? t('movie.comment_submitting') : t('movie.comment_submit')}
+          </button>
+        </div>
+      </form>
+
+      <div className="flex flex-col gap-4">
+        {comments.length === 0 && (
+          <p className="text-sm text-muted-foreground">{t('movie.no_comments')}</p>
+        )}
+        {comments.map(comment => (
+          <div key={comment.id} className="flex gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-full overflow-hidden bg-muted border border-border">
+              {comment.avatar_url ? (
+                <img src={comment.avatar_url} alt={comment.username} className="w-full h-full object-cover" />
+              ) : (
+                <span className="w-full h-full flex items-center justify-center text-sm font-bold text-muted-foreground">
+                  {comment.username?.charAt(0).toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1 min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{comment.username}</span>
+                <span className="text-xs text-muted-foreground">{formatDate(comment.created_at)}</span>
+              </div>
+              <p className="text-sm text-muted-foreground break-words">{comment.content}</p>
+            </div>
+            <button
+              onClick={() => handleDelete(comment.id)}
+              className="shrink-0 text-xs text-muted-foreground hover:text-destructive transition-colors self-start mt-0.5"
+              aria-label={t('movie.comment_delete')}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/page/MovieCard.tsx
+++ b/frontend/src/components/page/MovieCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Movie } from '@/hooks/useMovies'
@@ -7,12 +8,11 @@ import type { Movie } from '@/hooks/useMovies'
 interface MovieCardProps {
   movie: Movie
   watched: boolean
-  onToggle: () => void
 }
 
-export function MovieCard({ movie, watched, onToggle }: MovieCardProps) {
+export function MovieCard({ movie, watched }: MovieCardProps) {
   return (
-    <div className="group cursor-pointer flex flex-col" onClick={onToggle}>
+    <Link href={`/movies/${movie.id}`} className="group cursor-pointer flex flex-col">
       <div className={cn('card-glow bg-card border rounded-lg overflow-hidden flex flex-col flex-1', watched && 'opacity-50')}>
         <div className="bg-muted w-full aspect-[2/3] overflow-hidden flex items-center justify-center">
           {movie.poster_url ? (
@@ -40,7 +40,7 @@ export function MovieCard({ movie, watched, onToggle }: MovieCardProps) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
+
+interface Torrent {
+  url: string
+  hash: string
+  quality: string
+  type: string
+  size: string
+  seeds: number
+  peers: number
+  magnet: string
+}
+
+type PlayerState = 'idle' | 'starting' | 'downloading' | 'streaming' | 'error'
+
+interface MoviePlayerProps {
+  torrents: Torrent[]
+  movieId: number
+}
+
+export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
+  const { t } = useTranslation()
+  const [selected, setSelected] = useState<Torrent | null>(torrents[0] ?? null)
+  const [state, setState] = useState<PlayerState>('idle')
+  const [progress, setProgress] = useState(0)
+  const [infoHash, setInfoHash] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => stopPolling(), [stopPolling])
+
+  const pollStatus = useCallback((hash: string) => {
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
+        if (!res.ok) return
+        const json = await res.json()
+        const { status, progress: prog } = json.data ?? json
+
+        if (status === 'error') {
+          stopPolling()
+          setState('error')
+          setErrorMsg(t('movie.error_stream'))
+          return
+        }
+
+        setProgress(Math.round((prog ?? 0) * 100))
+
+        if (status === 'downloading' || status === 'completed') {
+          stopPolling()
+          setState('streaming')
+        }
+      } catch {
+        // keep polling on transient errors
+      }
+    }, 2000)
+  }, [stopPolling, t])
+
+  const handleWatch = useCallback(async () => {
+    if (!selected) return
+    setState('starting')
+    setErrorMsg(null)
+
+    try {
+      const res = await fetch('/api/v1/torrent/download', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ magnet_uri: selected.magnet, movie_id: movieId }),
+      })
+      if (!res.ok) throw new Error(`${res.status}`)
+      const json = await res.json()
+      const hash = json.data?.info_hash ?? json.info_hash
+      setInfoHash(hash)
+      setState('downloading')
+      pollStatus(hash)
+    } catch {
+      setState('error')
+      setErrorMsg(t('movie.error_stream'))
+    }
+  }, [selected, movieId, pollStatus, t])
+
+  if (!torrents.length) {
+    return (
+      <p className="text-sm text-muted-foreground">{t('movie.no_torrents')}</p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {state === 'streaming' && infoHash ? (
+        <video
+          ref={videoRef}
+          src={`/api/v1/stream/${infoHash}`}
+          controls
+          preload="metadata"
+          crossOrigin="use-credentials"
+          className="w-full rounded-lg bg-black aspect-video"
+        >
+          {t('movie.video_unsupported')}
+        </video>
+      ) : (
+        <div className="w-full aspect-video rounded-lg bg-muted flex items-center justify-center">
+          {state === 'idle' && (
+            <span className="text-muted-foreground text-sm">{t('movie.select_quality')}</span>
+          )}
+          {state === 'starting' && (
+            <span className="text-muted-foreground text-sm animate-pulse">{t('movie.loading')}</span>
+          )}
+          {state === 'downloading' && (
+            <div className="flex flex-col items-center gap-3 w-48">
+              <span className="text-sm text-muted-foreground">
+                {t('movie.progress', { percent: progress })}
+              </span>
+              <div className="w-full h-2 bg-border rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-sidebar-primary transition-all duration-500"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          )}
+          {state === 'error' && (
+            <span className="text-destructive text-sm">{errorMsg}</span>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap gap-2">
+          {torrents.map(torrent => (
+            <button
+              key={torrent.hash}
+              onClick={() => { if (state === 'idle') setSelected(torrent) }}
+              disabled={state !== 'idle'}
+              className={cn(
+                'text-xs px-3 py-1.5 rounded-md border transition-colors',
+                selected?.hash === torrent.hash
+                  ? 'bg-sidebar-primary text-white border-sidebar-primary'
+                  : 'bg-muted border-border text-muted-foreground hover:border-sidebar-primary',
+                state !== 'idle' && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              {torrent.quality} {torrent.type && `· ${torrent.type}`}
+              {torrent.size && <span className="ml-1 opacity-70">{torrent.size}</span>}
+            </button>
+          ))}
+        </div>
+
+        {state === 'idle' && (
+          <button
+            onClick={handleWatch}
+            disabled={!selected}
+            className="px-4 py-1.5 rounded-md bg-sidebar-primary text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {t('movie.watch')}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/page/Thumbnails.tsx
+++ b/frontend/src/components/page/Thumbnails.tsx
@@ -18,7 +18,7 @@ const DEFAULT_FILTERS: MovieFilters = {
 export default function Thumbnails() {
   const [filters, setFilters] = useState<MovieFilters>(DEFAULT_FILTERS)
   const [debouncedQuery, setDebouncedQuery] = useState('')
-  const [watchedMovies, setWatchedMovies] = useState<Set<number>>(new Set())
+  const [watchedMovies] = useState<Set<number>>(new Set())
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -33,15 +33,6 @@ export default function Thumbnails() {
 
   const handleFilterChange = useCallback((key: keyof Omit<MovieFilters, 'query'>, value: string) => {
     setFilters(prev => ({ ...prev, [key]: value }))
-  }, [])
-
-  const toggleWatched = useCallback((id: number) => {
-    setWatchedMovies(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
   }, [])
 
   useEffect(() => {
@@ -74,7 +65,6 @@ export default function Thumbnails() {
                   key={movie.id}
                   movie={movie}
                   watched={watchedMovies.has(movie.id)}
-                  onToggle={() => toggleWatched(movie.id)}
                 />
               ))
           }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -88,6 +88,23 @@
     "sort_downloads": "Downloads"
   },
 
+  "movie": {
+    "watch": "Watch",
+    "select_quality": "Select a quality to start",
+    "loading": "Loading…",
+    "progress": "Downloading {{percent}}%",
+    "error_stream": "Failed to start the stream",
+    "no_torrents": "No torrents available",
+    "video_unsupported": "Your browser does not support video playback.",
+    "comments_title": "Comments",
+    "comment_placeholder": "Add a comment…",
+    "comment_submit": "Post",
+    "comment_submitting": "Posting…",
+    "comment_delete": "Delete",
+    "comment_error": "Failed to post comment.",
+    "no_comments": "No comments yet for this movie."
+  },
+
   "Log Out": "Log Out",
     "Email": "Email",
     "Name": "Name",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -88,6 +88,23 @@
     "sort_downloads": "Téléchargements"
   },
 
+  "movie": {
+    "watch": "Regarder",
+    "select_quality": "Sélectionnez une qualité pour lancer",
+    "loading": "Chargement…",
+    "progress": "Téléchargement {{percent}}%",
+    "error_stream": "Erreur lors du lancement du stream",
+    "no_torrents": "Aucun torrent disponible",
+    "video_unsupported": "Votre navigateur ne supporte pas la lecture vidéo.",
+    "comments_title": "Commentaires",
+    "comment_placeholder": "Ajouter un commentaire…",
+    "comment_submit": "Publier",
+    "comment_submitting": "Publication…",
+    "comment_delete": "Supprimer",
+    "comment_error": "Impossible d'ajouter le commentaire.",
+    "no_comments": "Aucun commentaire pour ce film."
+  },
+
   "Log Out": "Déconnexion",
     "Email": "Email",
     "Name": "Nom",


### PR DESCRIPTION
## Résumé

- Nouvelle page détail `/movies/[id]` avec backdrop, poster, casting, genres et note
- `MoviePlayer` : sélection de qualité torrent, déclenchement du téléchargement, polling de progression et lecture HLS via `<video>`
- `CommentSection` : affichage, ajout et suppression de commentaires
- **fix(library)** : fallback YTS quand TMDB est indisponible ou ne retourne rien ; enrichissement des torrents via l'IMDb id
- **fix(torrent)** : ajout de `g++` dans le Dockerfile dev (dépendance CGO `go-libutp`) ; résolution du `tmdb_id` → `movies.id` local avant insertion du torrent pour éviter la violation de contrainte FK

## Plan de test

- [ ] Ouvrir la page d'un film TMDB → backdrop + métadonnées + torrents YTS affichés
- [ ] Ouvrir la page d'un film YTS-only (sans TMDB) → fallback fonctionne
- [ ] Cliquer « Regarder » → progression visible, puis lecture vidéo
- [ ] Poster un commentaire → apparaît en tête de liste
- [ ] Supprimer son propre commentaire → disparaît de la liste
- [ ] Vérifier qu'aucune erreur FK n'apparaît dans les logs torrent-service au premier download