### PR TITLE
feat(#23): page profil utilisateur — profil public, upload avatar et commentaires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ profile.cov
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-
+volumes/
 # Go workspace file
 go.work
 go.work.sum

--- a/api/comment-service/src/handlers/comment.go
+++ b/api/comment-service/src/handlers/comment.go
@@ -11,6 +11,60 @@ import (
 	"comment-service/src/utils"
 )
 
+func ListCommentsByUser(c *gin.Context) {
+	userID, err := strconv.Atoi(c.Param("userId"))
+	if err != nil {
+		utils.RespondError(c, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	type row struct {
+		ID        uint   `gorm:"column:id"`
+		UserID    int    `gorm:"column:user_id"`
+		Username  string `gorm:"column:username"`
+		AvatarURL string `gorm:"column:avatar_url"`
+		Content   string `gorm:"column:content"`
+		CreatedAt string `gorm:"column:created_at"`
+		MovieID   int    `gorm:"column:movie_id"`
+		TMDbID    int    `gorm:"column:tmdb_id"`
+		Title     string `gorm:"column:title"`
+	}
+
+	var rows []row
+	conf.DB.Raw(`
+		SELECT c.id, c.user_id, u.username, u.avatar_url, c.content, c.created_at,
+		       c.movie_id, m.tmdb_id, m.title
+		FROM comments c
+		INNER JOIN users u ON u.id = c.user_id
+		INNER JOIN movies m ON m.id = c.movie_id
+		WHERE c.user_id = ?
+		ORDER BY c.created_at DESC
+	`, userID).Scan(&rows)
+
+	type UserComment struct {
+		ID        uint   `json:"id"`
+		Content   string `json:"content"`
+		CreatedAt string `json:"created_at"`
+		MovieID   int    `json:"movie_id"`
+		TMDbID    int    `json:"tmdb_id"`
+		Title     string `json:"title"`
+	}
+
+	result := make([]UserComment, 0, len(rows))
+	for _, r := range rows {
+		result = append(result, UserComment{
+			ID:        r.ID,
+			Content:   r.Content,
+			CreatedAt: r.CreatedAt,
+			MovieID:   r.MovieID,
+			TMDbID:    r.TMDbID,
+			Title:     r.Title,
+		})
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, result)
+}
+
 type createCommentRequest struct {
 	Content string `json:"content" binding:"required,min=1,max=2000"`
 	Title   string `json:"title"`

--- a/api/comment-service/src/main.go
+++ b/api/comment-service/src/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 	"os"
@@ -11,25 +10,6 @@ import (
 	"comment-service/src/conf"
 	"comment-service/src/handlers"
 )
-
-type standardResponse struct {
-	Success bool        `json:"success"`
-	Error   string      `json:"error,omitempty"`
-	Data    interface{} `json:"data,omitempty"`
-}
-
-func respondJSON(w http.ResponseWriter, status int, body standardResponse) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(body) //nolint:errcheck
-}
-
-func notImplemented(w http.ResponseWriter, r *http.Request) {
-	respondJSON(w, http.StatusNotImplemented, standardResponse{
-		Success: false,
-		Error:   "comment service not yet implemented",
-	})
-}
 
 func main() {
 	if err := conf.InitDB(); err != nil {
@@ -43,7 +23,6 @@ func main() {
 
 	r := gin.Default()
 
-<<<<<<< 14-library-détail-dun-film
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "service": "comment-service"})
 	})
@@ -52,21 +31,12 @@ func main() {
 	{
 		comments := api.Group("/comments")
 		{
+			comments.GET("/user/:userId", handlers.ListCommentsByUser)
 			comments.GET("/:movieId", handlers.ListComments)
 			comments.POST("/:movieId", handlers.CreateComment)
 			comments.DELETE("/:id", handlers.DeleteComment)
 		}
 	}
-=======
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		respondJSON(w, http.StatusOK, standardResponse{
-			Success: true,
-			Data:    map[string]string{"status": "ok", "service": "comment-service"},
-		})
-	})
-
-	mux.HandleFunc("/api/v1/comments/", notImplemented)
->>>>>>> main
 
 	log.Printf("comment-service starting on port %s", port)
 	log.Fatal(http.ListenAndServe(":"+port, r))

--- a/api/gateway/src/proxy/proxy.go
+++ b/api/gateway/src/proxy/proxy.go
@@ -87,6 +87,7 @@ func replacePlaceholders(path string, c *gin.Context) string {
 	result := path
 	for _, param := range c.Params {
 		result = strings.ReplaceAll(result, ":"+param.Key, param.Value)
+		result = strings.ReplaceAll(result, "*"+param.Key, param.Value)
 	}
 	return result
 }

--- a/api/gateway/src/routes/comment.go
+++ b/api/gateway/src/routes/comment.go
@@ -11,6 +11,7 @@ func SetupCommentRoutes(r *gin.Engine) {
 	comment := r.Group("/api/v1/comments")
 	comment.Use(middleware.JWTMiddleware())
 	{
+		comment.GET("/user/:userId", proxy.ProxyRequest("comment", "/api/v1/comments/user/:userId"))
 		comment.GET("/:movieId", proxy.ProxyRequest("comment", "/api/v1/comments/:movieId"))
 		comment.POST("/:movieId", proxy.ProxyRequest("comment", "/api/v1/comments/:movieId"))
 		comment.DELETE("/:id", proxy.ProxyRequest("comment", "/api/v1/comments/:id"))

--- a/api/gateway/src/routes/user.go
+++ b/api/gateway/src/routes/user.go
@@ -15,6 +15,7 @@ func SetupUserRoutes(r *gin.Engine) {
 
 	users := r.Group("/api/v1/users")
 	{
+		users.GET("/avatars/*filename", proxy.ProxyRequest("user", "/api/v1/users/avatars*filename"))
 		users.GET(profileByID, proxy.ProxyRequest("user", upstreamProfileByID))
 		users.GET("/:id/online-status", proxy.ProxyRequest("user", "/api/v1/users/:id/online-status"))
 
@@ -24,6 +25,7 @@ func SetupUserRoutes(r *gin.Engine) {
 			protected.GET("/profile", proxy.ProxyRequest("user", "/api/v1/users/profile"))
 			protected.PUT(profileByID, proxy.ProxyRequest("user", upstreamProfileByID))
 			protected.DELETE(profileByID, proxy.ProxyRequest("user", upstreamProfileByID))
+			protected.POST("/avatar", proxy.ProxyRequest("user", "/api/v1/users/avatar"))
 		}
 	}
 }

--- a/api/user-service/src/handlers/avatar_upload.go
+++ b/api/user-service/src/handlers/avatar_upload.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"user-service/src/conf"
+	"user-service/src/models"
+	"user-service/src/utils"
+)
+
+func UploadAvatarHandler(c *gin.Context) {
+	userID, err := utils.GetAuthenticatedUserID(c)
+	if err != nil {
+		return
+	}
+
+	file, header, err := c.Request.FormFile("avatar")
+	if err != nil {
+		utils.RespondError(c, http.StatusBadRequest, "avatar file is required")
+		return
+	}
+	defer file.Close()
+
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	allowed := map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true}
+	if !allowed[ext] {
+		utils.RespondError(c, http.StatusBadRequest, "unsupported image format")
+		return
+	}
+
+	avatarDir := os.Getenv("AVATAR_DIR")
+	if avatarDir == "" {
+		avatarDir = "/data/avatars"
+	}
+	if err := os.MkdirAll(avatarDir, 0755); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to create upload directory")
+		return
+	}
+
+	filename := fmt.Sprintf("%d_%d%s", userID, time.Now().UnixNano(), ext)
+	dst := filepath.Join(avatarDir, filename)
+
+	buf := make([]byte, 5<<20)
+	n, _ := file.Read(buf)
+	if err := os.WriteFile(dst, buf[:n], 0644); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to save avatar")
+		return
+	}
+
+	avatarURL := fmt.Sprintf("/api/v1/users/avatars/%s", filename)
+
+	var user models.User
+	if err := conf.DB.First(&user, userID).Error; err != nil {
+		utils.RespondError(c, http.StatusNotFound, "user not found")
+		return
+	}
+
+	if user.AvatarURL != "" && strings.HasPrefix(user.AvatarURL, "/api/v1/users/avatars/") {
+		old := filepath.Join(avatarDir, filepath.Base(user.AvatarURL))
+		os.Remove(old)
+	}
+
+	user.AvatarURL = avatarURL
+	if err := conf.DB.Save(&user).Error; err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to update avatar")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"avatar_url": avatarURL})
+}

--- a/api/user-service/src/main.go
+++ b/api/user-service/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gin-gonic/gin"
 
@@ -26,6 +27,12 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "service": "user-service"})
 	})
 
+	avatarDir := os.Getenv("AVATAR_DIR")
+	if avatarDir == "" {
+		avatarDir = "/data/avatars"
+	}
+	r.Static("/api/v1/users/avatars", avatarDir)
+
 	const profileByID = "/profile/:id"
 
 	users := r.Group("/api/v1/users")
@@ -39,6 +46,7 @@ func main() {
 			protected.GET("/profile", handlers.GetOwnProfileHandler)
 			protected.PUT(profileByID, handlers.UpdateProfileHandler)
 			protected.DELETE(profileByID, handlers.DeleteProfileHandler)
+			protected.POST("/avatar", handlers.UploadAvatarHandler)
 		}
 	}
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -164,11 +164,13 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-password}
       REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
       GIN_MODE: debug
+      AVATAR_DIR: /data/avatars
     volumes:
       - ./api/user-service/src:/app/src
       - ./api/user-service/go.mod:/app/go.mod
       - ./api/user-service/go.sum:/app/go.sum
       - ./api/user-service/.air.toml:/app/.air.toml
+      - avatar_data:/data/avatars
     depends_on:
       - postgres
       - redis
@@ -180,6 +182,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - DAC_OVERRIDE
 
   library-service:
     build:
@@ -333,6 +337,7 @@ services:
       - /tmp
 
 volumes:
+  avatar_data:
   postgres_data_dev:
     driver: local
     driver_opts:

--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 import type { ReactNode } from 'react'
+import React from 'react'
 import LogoutButton from '@/app/(auth)/logout/logout'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
@@ -13,6 +14,21 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname()
   const { t } = useTranslation()
   const isProfilePage = pathname.includes('/profile')
+  const [avatarUrl, setAvatarUrl] = React.useState('')
+  const [initials, setInitials] = React.useState('HT')
+
+  React.useEffect(() => {
+    fetch('/api/v1/users/profile', { credentials: 'include' })
+      .then((r) => r.json())
+      .then(({ data }) => {
+        const p = data?.profile
+        if (!p) return
+        setAvatarUrl(p.avatar_url || `https://robohash.org/${p.id}.png?set=set1`)
+        const i = ((p.first_name?.[0] ?? '') + (p.last_name?.[0] ?? '')).toUpperCase() || p.username?.[0]?.toUpperCase() || 'HT'
+        setInitials(i)
+      })
+      .catch(() => {})
+  }, [])
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -26,8 +42,8 @@ export default function MainLayout({ children }: { children: ReactNode }) {
           ) : (
             <Link href="/profile">
               <Avatar className="size-10 cursor-pointer hover:opacity-80 transition-opacity">
-                <AvatarImage src="https://robohash.org/1.png?set=set1" alt="Avatar" />
-                <AvatarFallback>HT</AvatarFallback>
+                <AvatarImage src={avatarUrl} alt="Avatar" />
+                <AvatarFallback>{initials}</AvatarFallback>
               </Avatar>
             </Link>
           )}

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -4,34 +4,136 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTranslation } from 'react-i18next'
+import { CheckCircle, XCircle, Loader2 } from 'lucide-react'
+
+const LANGUAGES = [
+  { code: 'fr', label: '🇫🇷 Français' },
+  { code: 'en', label: '🇬🇧 English' },
+]
+
+interface UserProfile {
+  id: number
+  username: string
+  email: string
+  first_name: string
+  last_name: string
+  avatar_url: string
+}
+
+type SaveStatus = 'idle' | 'loading' | 'success' | 'error'
 
 export default function ProfilePage() {
+  const { t, i18n } = useTranslation()
   const [isEditing, setIsEditing] = React.useState(false)
-  const [profileImage, setProfileImage] = React.useState('https://robohash.org/1.png?set=set1')
+  const [profile, setProfile] = React.useState<UserProfile | null>(null)
+  const [firstName, setFirstName] = React.useState('')
+  const [lastName, setLastName] = React.useState('')
+  const [selectedLang, setSelectedLang] = React.useState(i18n.language)
+  const [profileImage, setProfileImage] = React.useState('')
+  const [saveStatus, setSaveStatus] = React.useState<SaveStatus>('idle')
+  const [errorMsg, setErrorMsg] = React.useState('')
   const fileInputRef = React.useRef<HTMLInputElement>(null)
-  const { t } = useTranslation()
+
+  React.useEffect(() => {
+    fetch('/api/v1/users/profile', { credentials: 'include' })
+      .then((r) => r.json())
+      .then(({ data }) => {
+        const p: UserProfile = data.profile
+        setProfile(p)
+        setFirstName(p.first_name)
+        setLastName(p.last_name)
+        setProfileImage(p.avatar_url || `https://robohash.org/${p.id}.png?set=set1`)
+      })
+      .catch(() => {})
+  }, [])
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
       const reader = new FileReader()
-      reader.onload = (event) => {
-        setProfileImage(event.target?.result as string)
-      }
+      reader.onload = (event) => setProfileImage(event.target?.result as string)
       reader.readAsDataURL(file)
     }
+  }
+
+  const handleSave = async () => {
+    if (!profile) return
+    setSaveStatus('loading')
+    setErrorMsg('')
+    try {
+      const res = await fetch(`/api/v1/users/profile/${profile.id}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ first_name: firstName, last_name: lastName }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setErrorMsg(body.error ?? t('profile.save_error'))
+        setSaveStatus('error')
+        return
+      }
+      const { data } = await res.json()
+      setProfile(data.profile)
+      await i18n.changeLanguage(selectedLang)
+      setSaveStatus('success')
+      setIsEditing(false)
+      setTimeout(() => setSaveStatus('idle'), 3000)
+    } catch {
+      setErrorMsg(t('profile.save_error'))
+      setSaveStatus('error')
+    }
+  }
+
+  const handleCancel = () => {
+    if (profile) {
+      setFirstName(profile.first_name)
+      setLastName(profile.last_name)
+      setProfileImage(profile.avatar_url || `https://robohash.org/${profile.id}.png?set=set1`)
+    }
+    setSelectedLang(i18n.language)
+    setSaveStatus('idle')
+    setIsEditing(false)
   }
 
   return (
     <div className="container mx-auto p-6 max-w-2xl">
       <div className="flex mb-6 items-center justify-between gap-4">
-        <h1 className="text-3xl font-bold">{t('Profile')}</h1>
+        <h1 className="text-3xl font-bold">{t('profile.title')}</h1>
         <div className="flex items-center gap-2">
-          <Button variant="default" onClick={() => setIsEditing(!isEditing)}>
-            {isEditing ? t('profile.save') : t('profile.edit')}
-          </Button>
+          {isEditing ? (
+            <>
+              <Button variant="outline" onClick={handleCancel} disabled={saveStatus === 'loading'}>
+                {t('profile.cancel')}
+              </Button>
+              <Button variant="default" onClick={handleSave} disabled={saveStatus === 'loading'}>
+                {saveStatus === 'loading' ? (
+                  <Loader2 className="size-4 animate-spin mr-1" />
+                ) : null}
+                {t('profile.save')}
+              </Button>
+            </>
+          ) : (
+            <Button variant="default" onClick={() => setIsEditing(true)}>
+              {t('profile.edit')}
+            </Button>
+          )}
         </div>
       </div>
+
+      {saveStatus === 'success' && (
+        <div className="flex items-center gap-2 mb-4 text-sm text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-md px-4 py-2">
+          <CheckCircle className="size-4 shrink-0" />
+          {t('profile.save_success')}
+        </div>
+      )}
+
+      {saveStatus === 'error' && (
+        <div className="flex items-center gap-2 mb-4 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-4 py-2">
+          <XCircle className="size-4 shrink-0" />
+          {errorMsg}
+        </div>
+      )}
 
       <Card className="card-glow">
         <CardHeader>
@@ -40,20 +142,23 @@ export default function ProfilePage() {
         <CardContent>
           <div className="flex gap-8 items-start">
             <div className="flex flex-col gap-4 flex-1">
+              {profile?.username && (
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-foreground">{t('profile.username')}</label>
+                  <Input value={profile.username} disabled />
+                </div>
+              )}
+
               <div className="space-y-1.5">
                 <label className="text-sm font-medium text-foreground">{t('Email')}</label>
-                <Input
-                  placeholder="Email"
-                  defaultValue="john.doe@example.com"
-                  disabled={!isEditing}
-                />
+                <Input value={profile?.email ?? ''} disabled />
               </div>
 
               <div className="space-y-1.5">
                 <label className="text-sm font-medium text-foreground">{t('Name')}</label>
                 <Input
-                  placeholder="Nom"
-                  defaultValue="Doe"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
                   disabled={!isEditing}
                 />
               </div>
@@ -61,19 +166,31 @@ export default function ProfilePage() {
               <div className="space-y-1.5">
                 <label className="text-sm font-medium text-foreground">{t('First name')}</label>
                 <Input
-                  placeholder="Prénom"
-                  defaultValue="John"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
                   disabled={!isEditing}
                 />
               </div>
 
               <div className="space-y-1.5">
-                <label className="text-sm font-medium text-foreground">{t('Password')}</label>
-                <Input
-                  type="password"
-                  placeholder="••••••••"
-                  disabled={!isEditing}
-                />
+                <label className="text-sm font-medium text-foreground">{t('profile.language')}</label>
+                <div className="flex gap-2">
+                  {LANGUAGES.map((lang) => (
+                    <button
+                      key={lang.code}
+                      type="button"
+                      disabled={!isEditing}
+                      onClick={() => isEditing && setSelectedLang(lang.code)}
+                      className={`flex-1 rounded-md border px-3 py-2 text-sm transition-colors ${
+                        selectedLang === lang.code
+                          ? 'border-sidebar-primary bg-sidebar-primary/10 font-semibold text-sidebar-primary'
+                          : 'border-border text-muted-foreground'
+                      } disabled:opacity-50 disabled:cursor-not-allowed`}
+                    >
+                      {lang.label}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
 
@@ -82,11 +199,9 @@ export default function ProfilePage() {
                 className={`relative w-40 h-40 rounded-lg overflow-hidden border-2 border-border transition-colors ${isEditing ? 'cursor-pointer hover:border-primary' : ''}`}
                 onClick={() => isEditing && fileInputRef.current?.click()}
               >
-                <img
-                  src={profileImage}
-                  alt="Profil"
-                  className="w-full h-full object-cover"
-                />
+                {profileImage && (
+                  <img src={profileImage} alt={t('profile.avatar_alt')} className="w-full h-full object-cover" />
+                )}
                 {isEditing && (
                   <div className="absolute inset-0 bg-background/60 flex items-center justify-center">
                     <span className="text-foreground text-sm font-medium">{t('profile.edit')}</span>

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -22,6 +22,13 @@ interface UserProfile {
 
 type SaveStatus = 'idle' | 'loading' | 'success' | 'error'
 
+function avatarSrc(profile: UserProfile | null, localPreview: string): string {
+  if (localPreview) return localPreview
+  if (profile?.avatar_url) return profile.avatar_url
+  if (profile?.id) return `https://robohash.org/${profile.id}.png?set=set1`
+  return ''
+}
+
 export default function ProfilePage() {
   const { t, i18n } = useTranslation()
   const [isEditing, setIsEditing] = React.useState(false)
@@ -29,7 +36,8 @@ export default function ProfilePage() {
   const [firstName, setFirstName] = React.useState('')
   const [lastName, setLastName] = React.useState('')
   const [selectedLang, setSelectedLang] = React.useState(i18n.language)
-  const [profileImage, setProfileImage] = React.useState('')
+  const [pendingFile, setPendingFile] = React.useState<File | null>(null)
+  const [localPreview, setLocalPreview] = React.useState('')
   const [saveStatus, setSaveStatus] = React.useState<SaveStatus>('idle')
   const [errorMsg, setErrorMsg] = React.useState('')
   const fileInputRef = React.useRef<HTMLInputElement>(null)
@@ -42,18 +50,17 @@ export default function ProfilePage() {
         setProfile(p)
         setFirstName(p.first_name)
         setLastName(p.last_name)
-        setProfileImage(p.avatar_url || `https://robohash.org/${p.id}.png?set=set1`)
       })
       .catch(() => {})
   }, [])
 
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImagePick = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file) {
-      const reader = new FileReader()
-      reader.onload = (event) => setProfileImage(event.target?.result as string)
-      reader.readAsDataURL(file)
-    }
+    if (!file) return
+    setPendingFile(file)
+    const reader = new FileReader()
+    reader.onload = (ev) => setLocalPreview(ev.target?.result as string)
+    reader.readAsDataURL(file)
   }
 
   const handleSave = async () => {
@@ -61,6 +68,26 @@ export default function ProfilePage() {
     setSaveStatus('loading')
     setErrorMsg('')
     try {
+      if (pendingFile) {
+        const form = new FormData()
+        form.append('avatar', pendingFile)
+        const res = await fetch('/api/v1/users/avatar', {
+          method: 'POST',
+          credentials: 'include',
+          body: form,
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}))
+          setErrorMsg(body.error ?? t('profile.save_error'))
+          setSaveStatus('error')
+          return
+        }
+        const { data } = await res.json()
+        setProfile((prev) => prev ? { ...prev, avatar_url: data.avatar_url } : prev)
+        setLocalPreview('')
+        setPendingFile(null)
+      }
+
       const res = await fetch(`/api/v1/users/profile/${profile.id}`, {
         method: 'PUT',
         credentials: 'include',
@@ -89,12 +116,15 @@ export default function ProfilePage() {
     if (profile) {
       setFirstName(profile.first_name)
       setLastName(profile.last_name)
-      setProfileImage(profile.avatar_url || `https://robohash.org/${profile.id}.png?set=set1`)
     }
+    setLocalPreview('')
+    setPendingFile(null)
     setSelectedLang(i18n.language)
     setSaveStatus('idle')
     setIsEditing(false)
   }
+
+  const imgSrc = avatarSrc(profile, localPreview)
 
   return (
     <div className="container mx-auto p-6 max-w-2xl">
@@ -107,9 +137,7 @@ export default function ProfilePage() {
                 {t('profile.cancel')}
               </Button>
               <Button variant="default" onClick={handleSave} disabled={saveStatus === 'loading'}>
-                {saveStatus === 'loading' ? (
-                  <Loader2 className="size-4 animate-spin mr-1" />
-                ) : null}
+                {saveStatus === 'loading' && <Loader2 className="size-4 animate-spin mr-1" />}
                 {t('profile.save')}
               </Button>
             </>
@@ -156,20 +184,12 @@ export default function ProfilePage() {
 
               <div className="space-y-1.5">
                 <label className="text-sm font-medium text-foreground">{t('Name')}</label>
-                <Input
-                  value={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-                  disabled={!isEditing}
-                />
+                <Input value={lastName} onChange={(e) => setLastName(e.target.value)} disabled={!isEditing} />
               </div>
 
               <div className="space-y-1.5">
                 <label className="text-sm font-medium text-foreground">{t('First name')}</label>
-                <Input
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                  disabled={!isEditing}
-                />
+                <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} disabled={!isEditing} />
               </div>
 
               <div className="space-y-1.5">
@@ -199,22 +219,16 @@ export default function ProfilePage() {
                 className={`relative w-40 h-40 rounded-lg overflow-hidden border-2 border-border transition-colors ${isEditing ? 'cursor-pointer hover:border-primary' : ''}`}
                 onClick={() => isEditing && fileInputRef.current?.click()}
               >
-                {profileImage && (
-                  <img src={profileImage} alt={t('profile.avatar_alt')} className="w-full h-full object-cover" />
+                {imgSrc && (
+                  <img src={imgSrc} alt={t('profile.avatar_alt')} className="w-full h-full object-cover" />
                 )}
                 {isEditing && (
                   <div className="absolute inset-0 bg-background/60 flex items-center justify-center">
-                    <span className="text-foreground text-sm font-medium">{t('profile.edit')}</span>
+                    <span className="text-foreground text-sm font-medium">{t('profile.change_avatar')}</span>
                   </div>
                 )}
               </div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleImageUpload}
-                className="hidden"
-              />
+              <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImagePick} className="hidden" />
             </div>
           </div>
         </CardContent>

--- a/frontend/src/app/(main)/users/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/[id]/page.tsx
@@ -1,0 +1,83 @@
+'use client'
+import React from 'react'
+import { useParams } from 'next/navigation'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { useTranslation } from 'react-i18next'
+
+interface PublicProfile {
+  id: number
+  username: string
+  first_name: string
+  last_name: string
+  avatar_url: string
+}
+
+export default function PublicProfilePage() {
+  const { id } = useParams<{ id: string }>()
+  const { t } = useTranslation()
+  const [profile, setProfile] = React.useState<PublicProfile | null>(null)
+  const [notFound, setNotFound] = React.useState(false)
+
+  React.useEffect(() => {
+    fetch(`/api/v1/users/profile/${id}`, { credentials: 'include' })
+      .then((r) => {
+        if (r.status === 404) { setNotFound(true); return null }
+        return r.json()
+      })
+      .then((body) => {
+        if (body) setProfile(body.data.profile)
+      })
+      .catch(() => setNotFound(true))
+  }, [id])
+
+  if (notFound) {
+    return (
+      <div className="container mx-auto p-6 max-w-2xl text-center text-muted-foreground">
+        {t('profile.user_not_found')}
+      </div>
+    )
+  }
+
+  if (!profile) {
+    return (
+      <div className="container mx-auto p-6 max-w-2xl text-center text-muted-foreground">
+        {t('profile.loading')}
+      </div>
+    )
+  }
+
+  const avatarSrc = profile.avatar_url || `https://robohash.org/${profile.id}.png?set=set1`
+  const initials = (profile.first_name?.[0] ?? '') + (profile.last_name?.[0] ?? '') || profile.username?.[0]?.toUpperCase()
+
+  return (
+    <div className="container mx-auto p-6 max-w-2xl">
+      <h1 className="text-3xl font-bold mb-6">{t('profile.public_title')}</h1>
+      <Card className="card-glow">
+        <CardHeader>
+          <CardTitle className="text-lg">{t('profile.info')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-8 items-center">
+            <Avatar className="size-28 rounded-lg">
+              <AvatarImage src={avatarSrc} alt={profile.username} className="object-cover" />
+              <AvatarFallback className="rounded-lg text-2xl">{initials}</AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-3">
+              <div>
+                <p className="text-xs text-muted-foreground mb-0.5">{t('profile.username')}</p>
+                <p className="font-semibold text-lg">{profile.username}</p>
+              </div>
+              {(profile.first_name || profile.last_name) && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-0.5">{t('profile.full_name')}</p>
+                  <p className="font-medium">{[profile.first_name, profile.last_name].filter(Boolean).join(' ')}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/users/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 import { useParams } from 'next/navigation'
+import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { useTranslation } from 'react-i18next'
@@ -13,10 +14,28 @@ interface PublicProfile {
   avatar_url: string
 }
 
+interface UserComment {
+  id: number
+  content: string
+  created_at: string
+  movie_id: number
+  tmdb_id: number
+  title: string
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
 export default function PublicProfilePage() {
   const { id } = useParams<{ id: string }>()
   const { t } = useTranslation()
   const [profile, setProfile] = React.useState<PublicProfile | null>(null)
+  const [comments, setComments] = React.useState<UserComment[]>([])
   const [notFound, setNotFound] = React.useState(false)
 
   React.useEffect(() => {
@@ -29,6 +48,11 @@ export default function PublicProfilePage() {
         if (body) setProfile(body.data.profile)
       })
       .catch(() => setNotFound(true))
+
+    fetch(`/api/v1/comments/user/${id}`, { credentials: 'include' })
+      .then((r) => r.json())
+      .then(({ data }) => setComments(data ?? []))
+      .catch(() => {})
   }, [id])
 
   if (notFound) {
@@ -51,8 +75,9 @@ export default function PublicProfilePage() {
   const initials = (profile.first_name?.[0] ?? '') + (profile.last_name?.[0] ?? '') || profile.username?.[0]?.toUpperCase()
 
   return (
-    <div className="container mx-auto p-6 max-w-2xl">
-      <h1 className="text-3xl font-bold mb-6">{t('profile.public_title')}</h1>
+    <div className="container mx-auto p-6 max-w-2xl flex flex-col gap-6">
+      <h1 className="text-3xl font-bold">{t('profile.public_title')}</h1>
+
       <Card className="card-glow">
         <CardHeader>
           <CardTitle className="text-lg">{t('profile.info')}</CardTitle>
@@ -76,6 +101,34 @@ export default function PublicProfilePage() {
               )}
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="card-glow">
+        <CardHeader>
+          <CardTitle className="text-lg">{t('profile.comments_title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {comments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('profile.no_comments')}</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-border">
+              {comments.map((c) => (
+                <div key={c.id} className="py-3 first:pt-0 last:pb-0 flex flex-col gap-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      href={`/movies/${c.tmdb_id}`}
+                      className="text-sm font-medium text-sidebar-primary hover:underline truncate"
+                    >
+                      {c.title}
+                    </Link>
+                    <span className="text-xs text-muted-foreground shrink-0">{formatDate(c.created_at)}</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground break-words">{c.content}</p>
+                </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,9 +6,20 @@
   },
 
   "profile": {
+    "title": "Profile",
+    "public_title": "User profile",
     "edit": "Edit",
     "save": "Save",
-    "info": "Personal information"
+    "cancel": "Cancel",
+    "info": "Personal information",
+    "username": "Username",
+    "full_name": "Full name",
+    "language": "Preferred language",
+    "save_success": "Profile updated successfully.",
+    "save_error": "Failed to update profile.",
+    "avatar_alt": "Avatar",
+    "loading": "Loading…",
+    "user_not_found": "User not found."
   },
 
   "auth": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -18,8 +18,11 @@
     "save_success": "Profile updated successfully.",
     "save_error": "Failed to update profile.",
     "avatar_alt": "Avatar",
+    "change_avatar": "Change",
     "loading": "Loading…",
-    "user_not_found": "User not found."
+    "user_not_found": "User not found.",
+    "comments_title": "Comments",
+    "no_comments": "This user hasn't commented on any movie yet."
   },
 
   "auth": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -18,8 +18,11 @@
     "save_success": "Profil mis à jour avec succès.",
     "save_error": "Impossible de mettre à jour le profil.",
     "avatar_alt": "Avatar",
+    "change_avatar": "Changer",
     "loading": "Chargement…",
-    "user_not_found": "Utilisateur introuvable."
+    "user_not_found": "Utilisateur introuvable.",
+    "comments_title": "Commentaires",
+    "no_comments": "Cet utilisateur n'a pas encore commenté de film."
   },
 
   "auth": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -6,9 +6,20 @@
   },
 
   "profile": {
+    "title": "Profil",
+    "public_title": "Profil utilisateur",
     "edit": "Modifier",
     "save": "Enregistrer",
-    "info": "Informations personnelles"
+    "cancel": "Annuler",
+    "info": "Informations personnelles",
+    "username": "Nom d'utilisateur",
+    "full_name": "Nom complet",
+    "language": "Langue préférée",
+    "save_success": "Profil mis à jour avec succès.",
+    "save_error": "Impossible de mettre à jour le profil.",
+    "avatar_alt": "Avatar",
+    "loading": "Chargement…",
+    "user_not_found": "Utilisateur introuvable."
   },
 
   "auth": {


### PR DESCRIPTION
## Résumé

- **`/profile`** : page privée connectée à l'API réelle — chargement du profil, modification des champs, upload d'avatar persisté côté serveur, sélection de la langue préférée, feedback visuel (succès/erreur)
- **`/users/:id`** : page de profil public affichant username, avatar et la liste des commentaires laissés par l'utilisateur (avec lien vers le film)
- **Navbar** : l'avatar affiché dans le header est maintenant le vrai avatar de l'utilisateur connecté
- **Backend** : endpoint d'upload multipart `POST /api/v1/users/avatar`, fichiers statiques servis par user-service, endpoint `GET /api/v1/comments/user/:userId`, résolution du conflit de merge dans comment-service

## Closes

Closes #23

## Plan de test

- [ ] Se connecter et aller sur `/profile` — les champs email/username/prénom/nom sont bien remplis depuis l'API
- [ ] Cliquer "Modifier", changer le prénom et sauvegarder → bandeau vert de confirmation
- [ ] Sélectionner un fichier image comme avatar → prévisualisation immédiate → sauvegarder → l'avatar persiste après rechargement
- [ ] L'avatar dans la navbar reflète le vrai avatar de l'utilisateur
- [ ] Aller sur `/users/:id` d'un utilisateur ayant commenté des films → ses commentaires apparaissent avec le titre du film cliquable
- [ ] Aller sur `/users/99999` (inexistant) → message "Utilisateur introuvable"