### PR TITLE
feat(#9): user-service — avatar upload MIME validation + language preference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DOCKER_COMPOSE_PATH_PROD	=	docker-compose.prode.yml
 all:
 	@if [ -f ".env" ]; then \
 		echo "Creating volumes..."; \
-		mkdir -p volumes/ volumes/redis volumes/data volumes/torrents; \
+		mkdir -p volumes/ volumes/redis volumes/data volumes/torrents volumes/avatars; \
 		echo "Launching containers..."; \
 		$(DOCKER_COMPOSE_CMD) --env-file .env -p $(NAME) -f $(DOCKER_COMPOSE_PATH) up --build -d; \
 	else \

--- a/api/user-service/README.md
+++ b/api/user-service/README.md
@@ -1,59 +1,115 @@
 # user-service
 
-Manages user profiles and online presence for Hypertube.
+Manages user profiles, avatar uploads, language preferences, and online presence for Hypertube.
 
 ## Responsibilities
 
 - Serve public and private user profiles
-- Accept profile updates (name, avatar)
+- Accept profile updates (first name, last name, language preference)
+- Handle avatar uploads with MIME type validation (jpeg, png, gif, webp — 5 MB max)
 - Delete accounts
-- Report online status via Redis presence
+- Report online/offline status via Redis presence
 
 ## Endpoints
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `GET` | `/health` | — | Health check |
-| `GET` | `/api/v1/users/profile/:id` | — | Get a user's public profile |
-| `GET` | `/api/v1/users/:id/online-status` | — | Get online status |
-| `GET` | `/api/v1/users/profile` | JWT | Get own profile |
-| `PUT` | `/api/v1/users/profile/:id` | JWT | Update own profile |
-| `DELETE` | `/api/v1/users/profile/:id` | JWT | Delete own account |
+| Method   | Path                              | Auth | Description                        |
+|----------|-----------------------------------|------|------------------------------------|
+| `GET`    | `/health`                         | —    | Health check                       |
+| `GET`    | `/api/v1/users/profile/:id`       | —    | Get a user's public profile        |
+| `GET`    | `/api/v1/users/:id/online-status` | —    | Get online status                  |
+| `GET`    | `/api/v1/users/avatars/*filename` | —    | Serve an uploaded avatar file      |
+| `GET`    | `/api/v1/users/profile`           | JWT  | Get own profile                    |
+| `PUT`    | `/api/v1/users/profile/:id`       | JWT  | Update own profile                 |
+| `DELETE` | `/api/v1/users/profile/:id`       | JWT  | Delete own account                 |
+| `POST`   | `/api/v1/users/avatar`            | JWT  | Upload avatar (`multipart/form-data`, field `avatar`) |
 
-Auth is enforced by the API Gateway, which forwards `X-User-ID` on protected routes.
+Auth is enforced by the API Gateway, which validates the JWT and forwards `X-User-ID` on protected routes.
+
+### `PUT /api/v1/users/profile/:id` — request body
+
+```json
+{
+  "first_name": "Jean",
+  "last_name":  "Dupont",
+  "language":   "fr"
+}
+```
+
+All fields are optional. `language` accepts `fr` or `en`.
+
+### `POST /api/v1/users/avatar` — response
+
+```json
+{
+  "data": {
+    "avatar_url": "/api/v1/users/avatars/42_1746612345678901234.jpg"
+  }
+}
+```
+
+## Data model
+
+```
+users
+├── id            SERIAL PK
+├── username      VARCHAR(50) UNIQUE NOT NULL
+├── email         VARCHAR(255) UNIQUE NOT NULL
+├── password_hash TEXT NOT NULL
+├── first_name    VARCHAR(100)
+├── last_name     VARCHAR(100)
+├── avatar_url    TEXT
+├── language      VARCHAR(10) DEFAULT 'fr'
+├── email_verified BOOLEAN DEFAULT FALSE
+├── created_at    TIMESTAMP
+└── updated_at    TIMESTAMP
+```
 
 ## Environment variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `8002` | Listening port |
-| `DB_HOST` | `localhost` | PostgreSQL host |
-| `DB_PORT` | `5432` | PostgreSQL port |
-| `DB_NAME` | `hypertube` | Database name |
-| `DB_USER` | `postgres` | Database user |
-| `DB_PASSWORD` | `password` | Database password |
-| `REDIS_HOST` | `redis` | Redis host |
-| `REDIS_PORT` | `6379` | Redis port |
-| `AUTO_MIGRATE` | `false` | Run GORM AutoMigrate on start |
+| Variable      | Default      | Description                          |
+|---------------|--------------|--------------------------------------|
+| `DB_HOST`     | `localhost`  | PostgreSQL host                      |
+| `DB_PORT`     | `5432`       | PostgreSQL port                      |
+| `DB_NAME`     | `hypertube`  | Database name                        |
+| `DB_USER`     | `postgres`   | Database user                        |
+| `DB_PASSWORD` | `password`   | Database password                    |
+| `REDIS_HOST`  | `redis`      | Redis host                           |
+| `REDIS_PORT`  | `6379`       | Redis port                           |
+| `AVATAR_DIR`  | `/data/avatars` | Directory where avatars are stored |
+| `AUTO_MIGRATE`| `false`      | Run GORM AutoMigrate on start        |
+
+The service listens on port **8002**.
 
 ## Layout
 
 ```
 src/
-├── conf/           # DB and Redis initialization
-├── handlers/       # HTTP handlers
-├── middleware/     # Auth middleware (reads X-User-ID from gateway)
-├── models/         # User GORM model
-├── services/       # Presence service (Redis)
-└── utils/          # Response helpers, validation
+├── conf/        # DB and Redis initialization
+├── handlers/    # HTTP handlers
+│   ├── avatar_upload.go      # POST /avatar — MIME validation + storage
+│   ├── GetOwnProfileHandler.go
+│   ├── online_status.go
+│   ├── profile_delete.go
+│   ├── profile_get.go
+│   ├── profile_update.go
+│   └── types.go              # Request structs
+├── middleware/  # Auth middleware (reads X-User-ID forwarded by gateway)
+├── models/      # User GORM model
+├── services/    # Presence service (Redis — online/offline tracking)
+└── utils/       # Response helpers, error helpers, validation
 ```
 
 ## Development
 
-Hot reload via [Air](https://github.com/air-verse/air):
+Hot reload via [Air](https://github.com/air-verse/air) — source files are volume-mounted:
 
 ```bash
 docker compose -f docker-compose.dev.yml up user-service
 ```
 
-Source files are volume-mounted — changes reload automatically.
+Run tests:
+
+```bash
+cd src
+go test -v ./...
+```

--- a/api/user-service/src/handlers/avatar_upload.go
+++ b/api/user-service/src/handlers/avatar_upload.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -15,22 +16,46 @@ import (
 	"user-service/src/utils"
 )
 
+const maxAvatarSize = 5 << 20 // 5 MB
+
+var allowedMIMETypes = map[string]string{
+	"image/jpeg": ".jpg",
+	"image/png":  ".png",
+	"image/gif":  ".gif",
+	"image/webp": ".webp",
+}
+
 func UploadAvatarHandler(c *gin.Context) {
 	userID, err := utils.GetAuthenticatedUserID(c)
 	if err != nil {
 		return
 	}
 
-	file, header, err := c.Request.FormFile("avatar")
+	file, _, err := c.Request.FormFile("avatar")
 	if err != nil {
 		utils.RespondError(c, http.StatusBadRequest, "avatar file is required")
 		return
 	}
 	defer file.Close()
 
-	ext := strings.ToLower(filepath.Ext(header.Filename))
-	allowed := map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true}
-	if !allowed[ext] {
+	// Read up to maxAvatarSize+1 to detect oversized files
+	limited := io.LimitReader(file, maxAvatarSize+1)
+	buf, err := io.ReadAll(limited)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to read file")
+		return
+	}
+	if len(buf) > maxAvatarSize {
+		utils.RespondError(c, http.StatusBadRequest, "avatar file exceeds 5 MB limit")
+		return
+	}
+
+	// Validate MIME type from actual file content (magic bytes)
+	mime := http.DetectContentType(buf)
+	// DetectContentType may return "image/jpeg" or "image/jpeg; charset=..." style
+	mime = strings.SplitN(mime, ";", 2)[0]
+	ext, ok := allowedMIMETypes[mime]
+	if !ok {
 		utils.RespondError(c, http.StatusBadRequest, "unsupported image format")
 		return
 	}
@@ -47,9 +72,7 @@ func UploadAvatarHandler(c *gin.Context) {
 	filename := fmt.Sprintf("%d_%d%s", userID, time.Now().UnixNano(), ext)
 	dst := filepath.Join(avatarDir, filename)
 
-	buf := make([]byte, 5<<20)
-	n, _ := file.Read(buf)
-	if err := os.WriteFile(dst, buf[:n], 0644); err != nil {
+	if err := os.WriteFile(dst, buf, 0644); err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "failed to save avatar")
 		return
 	}

--- a/api/user-service/src/handlers/profile_update.go
+++ b/api/user-service/src/handlers/profile_update.go
@@ -54,6 +54,14 @@ func UpdateProfileHandler(c *gin.Context) {
 		}
 		user.AvatarURL = *req.AvatarURL
 	}
+	if req.Language != nil {
+		allowed := map[string]bool{"fr": true, "en": true}
+		if !allowed[*req.Language] {
+			utils.RespondError(c, http.StatusBadRequest, "unsupported language")
+			return
+		}
+		user.Language = *req.Language
+	}
 
 	if err := conf.DB.Save(&user).Error; err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "failed to update profile")

--- a/api/user-service/src/handlers/types.go
+++ b/api/user-service/src/handlers/types.go
@@ -5,4 +5,5 @@ type UpdateProfileRequest struct {
 	FirstName *string `json:"first_name,omitempty"`
 	LastName  *string `json:"last_name,omitempty"`
 	AvatarURL *string `json:"avatar_url,omitempty"`
+	Language  *string `json:"language,omitempty"`
 }

--- a/api/user-service/src/models/user.go
+++ b/api/user-service/src/models/user.go
@@ -10,6 +10,7 @@ type User struct {
 	FirstName     string    `gorm:"column:first_name" json:"first_name"`
 	LastName      string    `gorm:"column:last_name" json:"last_name"`
 	AvatarURL     string    `gorm:"column:avatar_url" json:"avatar_url,omitempty"`
+	Language      string    `gorm:"column:language;type:varchar(10);default:'fr'" json:"language"`
 	EmailVerified bool      `gorm:"column:email_verified;default:false" json:"email_verified"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -132,6 +132,7 @@ services:
       FROM_EMAIL: ${FROM_EMAIL}
       FROM_NAME: ${FROM_NAME:-Hypertube}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+      AUTO_MIGRATE: ${AUTO_MIGRATE:-true}
     volumes:
       - ./api/auth-service/src:/app/src
       - ./api/auth-service/templates:/app/templates
@@ -164,6 +165,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-password}
       REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
       GIN_MODE: debug
+      AUTO_MIGRATE: true
       AVATAR_DIR: /data/avatars
     volumes:
       - ./api/user-service/src:/app/src
@@ -232,6 +234,7 @@ services:
       TORRENT_DOWNLOAD_PATH: /data/torrents
       STREAM_BUFFER_SIZE: ${STREAM_BUFFER_SIZE:-10}
       GIN_MODE: debug
+      AUTO_MIGRATE: ${AUTO_MIGRATE:-true}
     volumes:
       - ./api/torrent-service/src:/app/src
       - ./api/torrent-service/go.mod:/app/go.mod
@@ -262,6 +265,7 @@ services:
       DB_USER: ${DB_USER:-postgres}
       DB_PASSWORD: ${DB_PASSWORD:-password}
       GIN_MODE: debug
+      AUTO_MIGRATE: ${AUTO_MIGRATE:-true}
     volumes:
       - ./api/comment-service/src:/app/src
       - ./api/comment-service/go.mod:/app/go.mod
@@ -292,6 +296,8 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-password}
       REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
       TORRENT_DOWNLOAD_PATH: /data/torrents
+      GIN_MODE: debug
+      AUTO_MIGRATE: ${AUTO_MIGRATE:-true}
     volumes:
       - ./api/worker-service/src:/app/src
       - ./api/worker-service/go.mod:/app/go.mod
@@ -338,6 +344,11 @@ services:
 
 volumes:
   avatar_data:
+    driver: local
+    driver_opts:
+      type: none
+      device: ./volumes/avatars
+      o: bind 
   postgres_data_dev:
     driver: local
     driver_opts:

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -18,6 +18,7 @@ interface UserProfile {
   first_name: string
   last_name: string
   avatar_url: string
+  language: string
 }
 
 type SaveStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -50,6 +51,10 @@ export default function ProfilePage() {
         setProfile(p)
         setFirstName(p.first_name)
         setLastName(p.last_name)
+        if (p.language) {
+          setSelectedLang(p.language)
+          i18n.changeLanguage(p.language)
+        }
       })
       .catch(() => {})
   }, [])
@@ -92,7 +97,7 @@ export default function ProfilePage() {
         method: 'PUT',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ first_name: firstName, last_name: lastName }),
+        body: JSON.stringify({ first_name: firstName, last_name: lastName, language: selectedLang }),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))

--- a/services/database/03_user_tables.sql
+++ b/services/database/03_user_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE users (
     first_name  VARCHAR(100),
     last_name   VARCHAR(100),
     avatar_url  TEXT,
+    language    VARCHAR(10)  DEFAULT 'fr',
     email_verified BOOLEAN   DEFAULT FALSE,
     created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
     updated_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary

- **Avatar upload** : validation du MIME type réel (magic bytes via `http.DetectContentType`) au lieu de la seule extension, limite stricte à 5 MB via `io.LimitReader`
- **Préférence de langue** : champ `language` ajouté au modèle `User` (DB + GORM), persisté via `PUT /api/v1/users/profile/:id`, chargé et appliqué côté frontend au montage du profil
- **README** `user-service` : mis à jour avec tous les endpoints, le data model, les variables d'env et le layout

Closes #9

## Test plan

- [ ] Uploader une image valide (jpg, png, webp) → succès, `avatar_url` retourné
- [ ] Uploader un fichier renommé en `.jpg` mais non-image → rejeté 400
- [ ] Uploader un fichier > 5 MB → rejeté 400
- [ ] Changer la langue sur la page profil, sauvegarder, recharger la page → langue restaurée
- [ ] Vérifier que `language` est bien persisté en base (`fr` ou `en`)