### PR TITLE
fix(#70): allow msw and sharp build scripts for pnpm v10

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,5 +30,8 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["msw", "sharp"]
   }
 }


### PR DESCRIPTION
## Summary

- pnpm v10 blocks build scripts by default (`ERR_PNPM_IGNORED_BUILDS`)
- `sharp` (Next.js image optimization) and `msw` both require postinstall scripts
- Adding `onlyBuiltDependencies` to `package.json` approves these scripts without touching the frozen lockfile

Fixes #70