### PR TITLE
fix(#69): deduplicate movies on infinite scroll to prevent duplicate keys

### DIFF
--- a/frontend/src/hooks/useMovies.ts
+++ b/frontend/src/hooks/useMovies.ts
@@ -60,7 +60,12 @@ export function useMovies(filters: MovieFilters) {
       const json: MoviesResponse = await res.json()
       const { results, next_cursor } = json.data
 
-      setMovies(prev => reset ? (results ?? []) : [...prev, ...(results ?? [])])
+      setMovies(prev => {
+        if (reset) return results ?? []
+        const map = new Map(prev.map(m => [m.id, m]))
+        for (const m of results ?? []) map.set(m.id, m)
+        return Array.from(map.values())
+      })
       setNextCursor(next_cursor ?? null)
       setHasMore(!!next_cursor)
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- When loading additional pages via infinite scroll, the API can return movies that already exist in the current list
- Using `[...prev, ...results]` caused duplicate `key` props on `<MovieCard>`, triggering the React warning
- Now building a `Map` by `movie.id` when merging pages, ensuring each film appears only once

Fixes #69