### PR TITLE
fix: pin pnpm@10.33.0 and fix Docker build for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:22-alpine AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 # Development stage
 FROM base AS development
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 ENV NEXT_TELEMETRY_DISABLED=1
 # Ensure /app directory is writable by any user for development
@@ -15,7 +15,7 @@ CMD ["pnpm", "dev"]
 # Builder stage
 FROM base AS builder
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-ignoredBuiltDependencies:
+onlyBuiltDependencies:
+  - msw
   - sharp
-  - unrs-resolver


### PR DESCRIPTION
## Summary

- Pin `pnpm@10.33.0` in the Dockerfile instead of `@latest` — version mismatch between Docker pnpm and the lockfile was the root cause of `--frozen-lockfile` exit code 1
- Add `packageManager: pnpm@10.33.0` to `package.json` to document the version for corepack
- Copy `pnpm-workspace.yaml` into the Docker build context (both development and builder stages)
- Switch `pnpm-workspace.yaml` from `ignoredBuiltDependencies` to `onlyBuiltDependencies: [msw, sharp]` to explicitly allow their build scripts in pnpm v10

## Test plan

- [ ] `docker compose build` completes without error on the frontend image
- [ ] `pnpm install --frozen-lockfile` passes locally in `frontend/`