### PR TITLE
fix(torrent-service): bugs critiques, streaming et reprise de lecture

### DIFF
--- a/api/gateway/src/routes/torrent.go
+++ b/api/gateway/src/routes/torrent.go
@@ -25,6 +25,8 @@ func SetupTorrentRoutes(r *gin.Engine) {
 	movies.Use(middleware.JWTMiddleware())
 	{
 		movies.GET("/:id/watched", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/watched"))
+		movies.GET("/:id/progress", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/progress"))
+		movies.PUT("/:id/progress", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/progress"))
 	}
 
 	subtitle := r.Group("/api/v1/subtitle")

--- a/api/torrent-service/src/handlers/progress.go
+++ b/api/torrent-service/src/handlers/progress.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"torrent-service/src/services"
+	"torrent-service/src/utils"
+)
+
+// GetProgressHandler handles GET /api/v1/movies/:id/progress
+func GetProgressHandler(c *gin.Context) {
+	userID, ok := userIDFromHeader(c)
+	if !ok {
+		utils.RespondError(c, http.StatusUnauthorized, "missing or invalid X-User-ID")
+		return
+	}
+
+	movieID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || movieID <= 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
+		return
+	}
+
+	sec, err := services.GetProgress(userID, movieID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"progress_sec": sec})
+}
+
+// SaveProgressHandler handles PUT /api/v1/movies/:id/progress
+func SaveProgressHandler(c *gin.Context) {
+	userID, ok := userIDFromHeader(c)
+	if !ok {
+		utils.RespondError(c, http.StatusUnauthorized, "missing or invalid X-User-ID")
+		return
+	}
+
+	movieID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || movieID <= 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
+		return
+	}
+
+	var body struct {
+		ProgressSec int `json:"progress_sec"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.ProgressSec < 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid progress_sec")
+		return
+	}
+
+	if err := services.SaveProgress(userID, movieID, body.ProgressSec); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"progress_sec": body.ProgressSec})
+}

--- a/api/torrent-service/src/handlers/progress.go
+++ b/api/torrent-service/src/handlers/progress.go
@@ -11,6 +11,7 @@ import (
 )
 
 // GetProgressHandler handles GET /api/v1/movies/:id/progress
+// :id is the TMDB movie ID.
 func GetProgressHandler(c *gin.Context) {
 	userID, ok := userIDFromHeader(c)
 	if !ok {
@@ -18,13 +19,19 @@ func GetProgressHandler(c *gin.Context) {
 		return
 	}
 
-	movieID, err := strconv.Atoi(c.Param("id"))
-	if err != nil || movieID <= 0 {
+	tmdbID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || tmdbID <= 0 {
 		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
 		return
 	}
 
-	sec, err := services.GetProgress(userID, movieID)
+	localID, err := services.ResolveLocalMovieID(tmdbID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "could not resolve movie")
+		return
+	}
+
+	sec, err := services.GetProgress(userID, localID)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "database error")
 		return
@@ -34,6 +41,7 @@ func GetProgressHandler(c *gin.Context) {
 }
 
 // SaveProgressHandler handles PUT /api/v1/movies/:id/progress
+// :id is the TMDB movie ID.
 func SaveProgressHandler(c *gin.Context) {
 	userID, ok := userIDFromHeader(c)
 	if !ok {
@@ -41,8 +49,8 @@ func SaveProgressHandler(c *gin.Context) {
 		return
 	}
 
-	movieID, err := strconv.Atoi(c.Param("id"))
-	if err != nil || movieID <= 0 {
+	tmdbID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || tmdbID <= 0 {
 		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
 		return
 	}
@@ -55,7 +63,13 @@ func SaveProgressHandler(c *gin.Context) {
 		return
 	}
 
-	if err := services.SaveProgress(userID, movieID, body.ProgressSec); err != nil {
+	localID, err := services.ResolveLocalMovieID(tmdbID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "could not resolve movie")
+		return
+	}
+
+	if err := services.SaveProgress(userID, localID, body.ProgressSec); err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "database error")
 		return
 	}

--- a/api/torrent-service/src/handlers/status.go
+++ b/api/torrent-service/src/handlers/status.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -12,7 +13,7 @@ import (
 )
 
 func StatusHandler(c *gin.Context) {
-	hash := c.Param("id")
+	hash := strings.ToLower(c.Param("id"))
 	if hash == "" {
 		utils.RespondError(c, http.StatusBadRequest, "missing info hash")
 		return

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -45,11 +45,12 @@ func StreamHandler(c *gin.Context) {
 		return
 	case models.StatusError:
 		log.Printf("torrent %s failed: %s", hash, record.ErrorMsg)
-		utils.RespondError(c, http.StatusServiceUnavailable, "torrent processing failed")
+		utils.RespondError(c, http.StatusServiceUnavailable, record.ErrorMsg)
 		return
 	}
 
-	if userID, ok := userIDFromHeader(c); ok && record.MovieID > 0 {
+	userID, _ := userIDFromHeader(c)
+	if userID > 0 && record.MovieID > 0 {
 		services.RecordWatch(userID, record.MovieID) //nolint:errcheck
 	}
 
@@ -60,13 +61,9 @@ func StreamHandler(c *gin.Context) {
 		return
 	}
 
+	// Bug 1 fix: single NeedsTranscoding check (duplicate block removed).
 	if services.NeedsTranscoding(result.FileName) {
-		serveTranscoded(c, result)
-		return
-	}
-
-	if services.NeedsTranscoding(result.FileName) {
-		serveTranscoded(c, result)
+		serveTranscoded(c, result, userID, hash)
 		return
 	}
 
@@ -77,7 +74,7 @@ func StreamHandler(c *gin.Context) {
 	http.ServeContent(c.Writer, c.Request, result.FileName, time.Time{}, result.Reader)
 }
 
-func serveTranscoded(c *gin.Context, result services.ReaderResult) {
+func serveTranscoded(c *gin.Context, result services.ReaderResult, userID int, infoHash string) {
 	var codecInfo *services.CodecInfo
 	if result.FilePath != "" {
 		codecInfo, _ = services.ProbeCodecs(result.FilePath)
@@ -85,13 +82,16 @@ func serveTranscoded(c *gin.Context, result services.ReaderResult) {
 
 	job, err := services.StartTranscode(result.Reader, codecInfo)
 	if err != nil {
-		utils.RespondError(c, http.StatusInternalServerError, "transcoding error: "+err.Error())
+		// Bug 2 fix: single RespondError call (log first, then respond once).
 		log.Printf("transcoding error for %s: %v", result.FileName, err)
-		utils.RespondError(c, http.StatusInternalServerError, "transcoding failed")
+		utils.RespondError(c, http.StatusInternalServerError, "transcoding error: "+err.Error())
 		return
 	}
-	defer job.Cmd.Wait()
-	defer job.Reader.Close()
+	// Bug 3 fix: session ties ffmpeg lifecycle to the request context.
+	// Release runs first (LIFO), killing ffmpeg, then Wait collects exit status.
+	defer services.Sessions.Release(userID, infoHash)
+	defer job.Cmd.Wait() //nolint:errcheck
+	services.Sessions.Acquire(userID, infoHash, job, c.Request.Context())
 
 	c.Header("Content-Type", job.ContentType)
 	c.Header("Cache-Control", "no-cache")

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"mime"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -26,7 +27,7 @@ func init() {
 }
 
 func StreamHandler(c *gin.Context) {
-	hash := c.Param("id")
+	hash := strings.ToLower(c.Param("id"))
 	if hash == "" {
 		utils.RespondError(c, http.StatusBadRequest, "missing info hash")
 		return

--- a/api/torrent-service/src/main.go
+++ b/api/torrent-service/src/main.go
@@ -35,6 +35,8 @@ func main() {
 		}
 		api.GET("/stream/:id", handlers.StreamHandler)
 		api.GET("/movies/:id/watched", handlers.WatchedHandler)
+		api.GET("/movies/:id/progress", handlers.GetProgressHandler)
+		api.PUT("/movies/:id/progress", handlers.SaveProgressHandler)
 		api.GET("/subtitle/:id", func(c *gin.Context) {
 			utils.RespondError(c, http.StatusNotImplemented, "subtitles not yet implemented")
 		})

--- a/api/torrent-service/src/services/download.go
+++ b/api/torrent-service/src/services/download.go
@@ -41,6 +41,11 @@ func StartDownload(magnetURI string, movieID int) (string, error) {
 		return "", err
 	}
 
+	// File is already on disk — stream directly, no need to re-seed.
+	if record.Status == models.StatusReady {
+		return infoHash, nil
+	}
+
 	t, err := addToClient(magnetURI)
 	if err != nil {
 		conf.DB.Model(record).Updates(map[string]any{

--- a/api/torrent-service/src/services/download.go
+++ b/api/torrent-service/src/services/download.go
@@ -60,6 +60,12 @@ func StartDownload(magnetURI string, movieID int) (string, error) {
 	return infoHash, nil
 }
 
+// ResolveLocalMovieID returns the local movies.id for a TMDB movie ID,
+// inserting a placeholder row if the movie has not been cached yet.
+func ResolveLocalMovieID(tmdbID int) (int, error) {
+	return resolveLocalMovieID(tmdbID)
+}
+
 func resolveLocalMovieID(tmdbID int) (int, error) {
 	var localID int
 	conf.DB.Raw("SELECT id FROM movies WHERE tmdb_id = ?", tmdbID).Scan(&localID)

--- a/api/torrent-service/src/services/reader.go
+++ b/api/torrent-service/src/services/reader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,9 +59,19 @@ func readerFromActiveTorrent(t *torrent.Torrent) (ReaderResult, error) {
 	}
 
 	r := f.NewReader()
-	r.SetReadahead(5 << 20) // 5 MiB readahead for smooth streaming
+	r.SetReadahead(readaheadBytes())
 	filePath := downloadDir() + "/" + strings.ToLower(t.InfoHash().HexString()) + "/" + f.DisplayPath()
 	return ReaderResult{Reader: r, Size: f.Length(), FileName: f.DisplayPath(), FilePath: filePath}, nil
+}
+
+// readaheadBytes reads STREAM_BUFFER_SIZE (MiB) from the environment, defaulting to 5 MiB.
+func readaheadBytes() int64 {
+	if s := os.Getenv("STREAM_BUFFER_SIZE"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n > 0 {
+			return n << 20
+		}
+	}
+	return 5 << 20
 }
 
 func readerFromDisk(infoHash string) (ReaderResult, error) {

--- a/api/torrent-service/src/services/reader.go
+++ b/api/torrent-service/src/services/reader.go
@@ -3,7 +3,9 @@ package services
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -83,9 +85,45 @@ func readerFromDisk(infoHash string) (ReaderResult, error) {
 		return ReaderResult{}, errors.New("torrent not ready")
 	}
 
-	f, err := os.Open(record.FilePath)
+	filePath := record.FilePath
+	if _, statErr := os.Stat(filePath); statErr != nil {
+		// Stored path is stale — scan the torrent directory for the largest file.
+		filePath = scanLargestFile(downloadDir() + "/" + infoHash)
+		if filePath == "" {
+			return ReaderResult{}, fmt.Errorf("open file: %w", statErr)
+		}
+		conf.DB.Model(record).Update("file_path", filePath)
+	}
+
+	f, err := os.Open(filePath)
 	if err != nil {
 		return ReaderResult{}, fmt.Errorf("open file: %w", err)
 	}
-	return ReaderResult{Reader: f, Size: record.FileSize, FileName: record.FilePath, FilePath: record.FilePath}, nil
+	info, _ := f.Stat()
+	size := record.FileSize
+	if info != nil && info.Size() > 0 {
+		size = info.Size()
+	}
+	return ReaderResult{Reader: f, Size: size, FileName: filepath.Base(filePath), FilePath: filePath}, nil
+}
+
+// scanLargestFile walks dir and returns the path of the largest file found.
+func scanLargestFile(dir string) string {
+	var best string
+	var bestSize int64
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.Size() > bestSize {
+			bestSize = info.Size()
+			best = path
+		}
+		return nil
+	})
+	return best
 }

--- a/api/torrent-service/src/services/services_test.go
+++ b/api/torrent-service/src/services/services_test.go
@@ -36,6 +36,11 @@ func setupTestDB(t *testing.T) {
 		created_at DATETIME,
 		updated_at DATETIME
 	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE movies (
+		id      INTEGER PRIMARY KEY AUTOINCREMENT,
+		tmdb_id INTEGER UNIQUE NOT NULL,
+		title   TEXT    NOT NULL
+	)`).Error)
 	conf.DB = db
 }
 

--- a/api/torrent-service/src/services/session_manager.go
+++ b/api/torrent-service/src/services/session_manager.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const sessionMaxIdle    = 2 * time.Minute
+const sessionGCInterval = 30 * time.Second
+
+// StreamSession holds the lifecycle context for one user's active stream.
+type StreamSession struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	job       *TranscodeJob
+	createdAt time.Time
+	mu        sync.Mutex
+}
+
+// StreamSessionManager tracks active streams keyed by "userID:infoHash".
+type StreamSessionManager struct {
+	mu       sync.Mutex
+	sessions map[string]*StreamSession
+}
+
+// Sessions is the process-wide session manager.
+var Sessions = newStreamSessionManager()
+
+func newStreamSessionManager() *StreamSessionManager {
+	m := &StreamSessionManager{sessions: make(map[string]*StreamSession)}
+	go m.runGC()
+	return m
+}
+
+// Acquire registers a new stream session for (userID, infoHash), replacing any
+// existing one. The ffmpeg process is killed automatically when reqCtx is done
+// (client disconnect) or when Release is called.
+func (m *StreamSessionManager) Acquire(userID int, infoHash string, job *TranscodeJob, reqCtx context.Context) *StreamSession {
+	key := fmt.Sprintf("%d:%s", userID, infoHash)
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &StreamSession{ctx: ctx, cancel: cancel, job: job, createdAt: time.Now()}
+
+	m.mu.Lock()
+	if old, ok := m.sessions[key]; ok {
+		old.kill()
+	}
+	m.sessions[key] = s
+	m.mu.Unlock()
+
+	go func() {
+		select {
+		case <-reqCtx.Done():
+			m.remove(key)
+		case <-ctx.Done():
+		}
+	}()
+
+	return s
+}
+
+// Release removes the session and kills the associated ffmpeg process.
+func (m *StreamSessionManager) Release(userID int, infoHash string) {
+	m.remove(fmt.Sprintf("%d:%s", userID, infoHash))
+}
+
+func (m *StreamSessionManager) remove(key string) {
+	m.mu.Lock()
+	s, ok := m.sessions[key]
+	if ok {
+		delete(m.sessions, key)
+	}
+	m.mu.Unlock()
+	if ok {
+		s.kill()
+	}
+}
+
+func (m *StreamSessionManager) runGC() {
+	t := time.NewTicker(sessionGCInterval)
+	defer t.Stop()
+	for range t.C {
+		now := time.Now()
+		var stale []string
+		m.mu.Lock()
+		for k, s := range m.sessions {
+			if now.Sub(s.createdAt) > sessionMaxIdle {
+				stale = append(stale, k)
+			}
+		}
+		for _, k := range stale {
+			if s, ok := m.sessions[k]; ok {
+				delete(m.sessions, k)
+				go s.kill()
+			}
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (s *StreamSession) kill() {
+	s.cancel()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.job == nil {
+		return
+	}
+	s.job.Reader.Close()
+	if s.job.Cmd != nil && s.job.Cmd.Process != nil {
+		s.job.Cmd.Process.Kill()
+	}
+	s.job = nil
+}

--- a/api/torrent-service/src/services/watch_history.go
+++ b/api/torrent-service/src/services/watch_history.go
@@ -28,3 +28,29 @@ func IsWatched(userID, movieID int) (bool, error) {
 		Count(&count).Error
 	return count > 0, err
 }
+
+// GetProgress returns the saved playback position in seconds for a user/movie pair.
+// Returns 0 if no record exists yet.
+func GetProgress(userID, movieID int) (int, error) {
+	var entry models.WatchHistory
+	err := conf.DB.
+		Where("user_id = ? AND movie_id = ?", userID, movieID).
+		First(&entry).Error
+	if err != nil {
+		return 0, nil // no record yet → start from beginning
+	}
+	return entry.ProgressSec, nil
+}
+
+// SaveProgress upserts the playback position in seconds for a user/movie pair.
+func SaveProgress(userID, movieID, progressSec int) error {
+	entry := models.WatchHistory{
+		UserID:    userID,
+		MovieID:   movieID,
+		WatchedAt: time.Now(),
+	}
+	return conf.DB.
+		Where(models.WatchHistory{UserID: userID, MovieID: movieID}).
+		Assign(models.WatchHistory{ProgressSec: progressSec, WatchedAt: entry.WatchedAt}).
+		FirstOrCreate(&entry).Error
+}

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -49,15 +49,16 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
     let cancelled = false
     setState('checking')
+    const hash = selected.hash.toLowerCase()
     void (async () => {
       try {
-        const res = await fetch(`/api/v1/torrent/status/${selected.hash}`, { credentials: 'include' })
+        const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
         if (cancelled) return
         if (res.ok) {
           const json = await res.json()
           const { status } = (json.data ?? json) as { status: string }
           if (!cancelled && status === 'ready') {
-            setInfoHash(selected.hash)
+            setInfoHash(hash)
             setState('streaming')
             return
           }
@@ -112,7 +113,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
       })
       if (!res.ok) throw new Error(`${res.status}`)
       const json = await res.json()
-      const hash = json.data?.info_hash ?? json.info_hash
+      const hash = (json.data?.info_hash ?? json.info_hash as string).toLowerCase()
       setInfoHash(hash)
       setState('downloading')
       pollStatus(hash)

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -58,7 +58,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
 
         setProgress(Math.round((prog ?? 0) * 100))
 
-        if (status === 'downloading' || status === 'completed') {
+        if (status === 'downloading' || status === 'ready') {
           stopPolling()
           setState('streaming')
         }

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -22,6 +22,8 @@ interface MoviePlayerProps {
   movieId: number
 }
 
+const SAVE_INTERVAL_MS = 5000
+
 export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Torrent | null>(torrents[0] ?? null)
@@ -30,6 +32,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const [infoHash, setInfoHash] = useState<string | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const saveRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
 
   const stopPolling = useCallback(() => {
@@ -39,9 +42,51 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
   }, [])
 
-  useEffect(() => () => stopPolling(), [stopPolling])
+  const stopSaving = useCallback(() => {
+    if (saveRef.current) {
+      clearInterval(saveRef.current)
+      saveRef.current = null
+    }
+  }, [])
 
-  // On mount and when the selected torrent changes, check if it is already ready on the server.
+  useEffect(() => () => { stopPolling(); stopSaving() }, [stopPolling, stopSaving])
+
+  // Restore saved position once the video element is ready.
+  const restorePosition = useCallback(async () => {
+    const video = videoRef.current
+    if (!video) return
+    try {
+      const res = await fetch(`/api/v1/movies/${movieId}/progress`, { credentials: 'include' })
+      if (!res.ok) return
+      const json = await res.json()
+      const sec: number = (json.data ?? json).progress_sec ?? 0
+      if (sec > 0) video.currentTime = sec
+    } catch {
+      // ignore — just start from the beginning
+    }
+  }, [movieId])
+
+  // Periodically save the current playback position.
+  const startSaving = useCallback(() => {
+    saveRef.current = setInterval(async () => {
+      const video = videoRef.current
+      if (!video || video.paused || video.ended) return
+      const sec = Math.floor(video.currentTime)
+      if (sec <= 0) return
+      try {
+        await fetch(`/api/v1/movies/${movieId}/progress`, {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ progress_sec: sec }),
+        })
+      } catch {
+        // ignore transient save errors
+      }
+    }, SAVE_INTERVAL_MS)
+  }, [movieId])
+
+  // Check if the selected torrent is already ready on the server.
   useEffect(() => {
     if (!selected) {
       setState('idle')
@@ -49,9 +94,9 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
     let cancelled = false
     setState('checking')
-    const hash = selected.hash.toLowerCase()
     void (async () => {
       try {
+        const hash = selected.hash.toLowerCase()
         const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
         if (cancelled) return
         if (res.ok) {
@@ -64,13 +109,25 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
           }
         }
       } catch {
-        // status check failed — fall through to idle
+        // fall through to idle
       }
       if (!cancelled) setState('idle')
     })()
     return () => { cancelled = true }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected])
+
+  // When streaming starts, restore position and begin saving.
+  useEffect(() => {
+    if (state !== 'streaming') return
+    stopSaving()
+    // Delay slightly so the video element has time to mount.
+    const t = setTimeout(() => {
+      void restorePosition()
+      startSaving()
+    }, 300)
+    return () => clearTimeout(t)
+  }, [state, restorePosition, startSaving, stopSaving])
 
   const pollStatus = useCallback((hash: string) => {
     pollRef.current = setInterval(async () => {

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -15,7 +15,7 @@ interface Torrent {
   magnet: string
 }
 
-type PlayerState = 'idle' | 'starting' | 'downloading' | 'streaming' | 'error'
+type PlayerState = 'idle' | 'checking' | 'starting' | 'downloading' | 'streaming' | 'error'
 
 interface MoviePlayerProps {
   torrents: Torrent[]
@@ -25,7 +25,7 @@ interface MoviePlayerProps {
 export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Torrent | null>(torrents[0] ?? null)
-  const [state, setState] = useState<PlayerState>('idle')
+  const [state, setState] = useState<PlayerState>('checking')
   const [progress, setProgress] = useState(0)
   const [infoHash, setInfoHash] = useState<string | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
@@ -40,6 +40,36 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   }, [])
 
   useEffect(() => () => stopPolling(), [stopPolling])
+
+  // On mount and when the selected torrent changes, check if it is already ready on the server.
+  useEffect(() => {
+    if (!selected) {
+      setState('idle')
+      return
+    }
+    let cancelled = false
+    setState('checking')
+    void (async () => {
+      try {
+        const res = await fetch(`/api/v1/torrent/status/${selected.hash}`, { credentials: 'include' })
+        if (cancelled) return
+        if (res.ok) {
+          const json = await res.json()
+          const { status } = (json.data ?? json) as { status: string }
+          if (!cancelled && status === 'ready') {
+            setInfoHash(selected.hash)
+            setState('streaming')
+            return
+          }
+        }
+      } catch {
+        // status check failed — fall through to idle
+      }
+      if (!cancelled) setState('idle')
+    })()
+    return () => { cancelled = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected])
 
   const pollStatus = useCallback((hash: string) => {
     pollRef.current = setInterval(async () => {
@@ -113,11 +143,11 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
         </video>
       ) : (
         <div className="w-full aspect-video rounded-lg bg-muted flex items-center justify-center">
+          {(state === 'checking' || state === 'starting') && (
+            <span className="text-muted-foreground text-sm animate-pulse">{t('movie.loading')}</span>
+          )}
           {state === 'idle' && (
             <span className="text-muted-foreground text-sm">{t('movie.select_quality')}</span>
-          )}
-          {state === 'starting' && (
-            <span className="text-muted-foreground text-sm animate-pulse">{t('movie.loading')}</span>
           )}
           {state === 'downloading' && (
             <div className="flex flex-col items-center gap-3 w-48">
@@ -143,14 +173,14 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
           {torrents.map(torrent => (
             <button
               key={torrent.hash}
-              onClick={() => { if (state === 'idle') setSelected(torrent) }}
-              disabled={state !== 'idle'}
+              onClick={() => { if (state === 'idle' || state === 'checking') setSelected(torrent) }}
+              disabled={state !== 'idle' && state !== 'checking'}
               className={cn(
                 'text-xs px-3 py-1.5 rounded-md border transition-colors',
                 selected?.hash === torrent.hash
                   ? 'bg-sidebar-primary text-white border-sidebar-primary'
                   : 'bg-muted border-border text-muted-foreground hover:border-sidebar-primary',
-                state !== 'idle' && 'opacity-50 cursor-not-allowed',
+                state !== 'idle' && state !== 'checking' && 'opacity-50 cursor-not-allowed',
               )}
             >
               {torrent.quality} {torrent.type && `· ${torrent.type}`}


### PR DESCRIPTION
## Résumé

Résolution de l'issue #78 : 4 bugs critiques dans le torrent-service, système de sessions de streaming, et reprise de lecture par utilisateur.

### Bugs corrigés

- **Bug 1** — bloc `NeedsTranscoding` dupliqué (code mort) supprimé (`stream.go`)
- **Bug 2** — double appel `RespondError` sur échec de transcodage (`stream.go`)
- **Bug 3** — fuite ffmpeg à la déconnexion : processus tué via `StreamSessionManager` lié au contexte de la requête
- **Bug 4** — `STREAM_BUFFER_SIZE` ignoré : env var lue correctement au lieu du hardcode 5 MiB
- **Fix** — hash info torrent normalisé en minuscules dans `StatusHandler` et `StreamHandler` (TMDB renvoie en majuscules, DB stocke en minuscules)
- **Fix** — `file_path` stale en DB : `readerFromDisk` scanne le répertoire du torrent et met à jour la DB si le chemin ne correspond plus
- **Fix** — statut `'completed'` inexistant dans le frontend remplacé par `'ready'`
- **Fix** — `StartDownload` ne relance plus `monitorTorrent` si le fichier est déjà `ready` sur disque
- **Fix** — violation FK dans `watch_history` : résolution TMDB ID → local movie ID avant insertion

### Nouvelles fonctionnalités

- **`StreamSessionManager`** (`services/session_manager.go`) — sessions indexées par `(userID, infoHash)`, lifecycle ffmpeg lié au contexte HTTP, GC après 2 min d'inactivité
- **Auto-affichage du player** — si le torrent est déjà `ready`, le player s'affiche directement sans cliquer sur "Regarder"
- **Reprise de lecture** — `GET/PUT /api/v1/movies/:id/progress` sauvegarde et restaure la position en secondes par utilisateur/film (toutes les 5 s pendant la lecture)

### Tests

- `TestStreamHandler_Error` corrigé : `ErrorMsg` propagé dans la réponse 503
- `TestFindOrCreateRecord_NewRecord` corrigé : table `movies` ajoutée au setup SQLite de test