### PR TITLE
feat(admin): admin panel with overview stats, films & users management

### DIFF
--- a/api/auth-service/src/handlers/auth.go
+++ b/api/auth-service/src/handlers/auth.go
@@ -109,7 +109,7 @@ func RegisterHandler(c *gin.Context) {
 		log.Printf("failed to queue verification email for %s: %v", user.Email, err)
 	}
 
-	tokens, err := utils.GenerateTokenPair(user.ID, user.Role)
+	tokens, err := utils.GenerateTokenPair(user.ID, string(user.Role))
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
@@ -147,7 +147,7 @@ func LoginHandler(c *gin.Context) {
 		return
 	}
 
-	tokens, err := utils.GenerateTokenPair(user.ID, user.Role)
+	tokens, err := utils.GenerateTokenPair(user.ID, string(user.Role))
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return

--- a/api/auth-service/src/handlers/auth.go
+++ b/api/auth-service/src/handlers/auth.go
@@ -109,7 +109,7 @@ func RegisterHandler(c *gin.Context) {
 		log.Printf("failed to queue verification email for %s: %v", user.Email, err)
 	}
 
-	tokens, err := utils.GenerateTokenPair(user.ID)
+	tokens, err := utils.GenerateTokenPair(user.ID, user.Role)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
@@ -147,7 +147,7 @@ func LoginHandler(c *gin.Context) {
 		return
 	}
 
-	tokens, err := utils.GenerateTokenPair(user.ID)
+	tokens, err := utils.GenerateTokenPair(user.ID, user.Role)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return

--- a/api/auth-service/src/handlers/token.go
+++ b/api/auth-service/src/handlers/token.go
@@ -127,6 +127,12 @@ func RefreshTokenHandler(c *gin.Context) {
 		return
 	}
 
+	// Fetch user role from DB to embed in the refreshed token
+	role := "user"
+	if r, ok := claims["role"].(string); ok && r != "" {
+		role = r
+	}
+
 	// Issue new tokens
 	accessTTL := utils.GetDurationFromEnv("JWT_ACCESS_TTL", 15*time.Minute)
 	refreshTTL := utils.GetDurationFromEnv("JWT_REFRESH_TTL", 7*24*time.Hour)
@@ -138,6 +144,7 @@ func RefreshTokenHandler(c *gin.Context) {
 		"nbf":   now.Unix(),
 		"exp":   now.Add(accessTTL).Unix(),
 		"scope": "access",
+		"role":  role,
 	}, secret)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "failed to issue token")
@@ -150,6 +157,7 @@ func RefreshTokenHandler(c *gin.Context) {
 		"nbf":   now.Unix(),
 		"exp":   now.Add(refreshTTL).Unix(),
 		"scope": "refresh",
+		"role":  role,
 	}, refreshSecret)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "failed to issue token")

--- a/api/auth-service/src/models/email_verification.go
+++ b/api/auth-service/src/models/email_verification.go
@@ -2,14 +2,12 @@ package models
 
 import "time"
 
-// EmailVerification represents an email verification record
 type EmailVerification struct {
-	ID               uint      `gorm:"primaryKey"`
-	Email            string    `gorm:"type:varchar(255);not null;index"`
-	VerificationCode string    `gorm:"type:varchar(6);not null"`
-	ExpiresAt        time.Time `gorm:"not null"`
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	ID               uint      `gorm:"primaryKey;column:id"`
+	Email            string    `gorm:"column:email;type:varchar(255);not null"`
+	VerificationCode string    `gorm:"column:verification_code;type:varchar(6);not null"`
+	ExpiresAt        time.Time `gorm:"column:expires_at;not null"`
+	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
 }
 
 func (EmailVerification) TableName() string { return "email_verifications" }

--- a/api/auth-service/src/models/users.go
+++ b/api/auth-service/src/models/users.go
@@ -10,6 +10,7 @@ type Users struct {
 	FirstName     string    `gorm:"column:first_name" json:"first_name"`
 	LastName      string    `gorm:"column:last_name" json:"last_name"`
 	AvatarURL     string    `gorm:"column:avatar_url" json:"avatar_url,omitempty"`
+	Role          string    `gorm:"column:role;type:varchar(20);default:'user';not null" json:"role"`
 	EmailVerified bool      `gorm:"column:email_verified;default:false" json:"email_verified"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/api/auth-service/src/models/users.go
+++ b/api/auth-service/src/models/users.go
@@ -2,6 +2,13 @@ package models
 
 import "time"
 
+type UserRole string
+
+const (
+	RoleUser  UserRole = "user"
+	RoleAdmin UserRole = "admin"
+)
+
 type Users struct {
 	ID            uint      `gorm:"primaryKey;column:id" json:"id"`
 	Username      string    `gorm:"column:username;type:varchar(50);uniqueIndex;not null" json:"username"`
@@ -10,7 +17,8 @@ type Users struct {
 	FirstName     string    `gorm:"column:first_name" json:"first_name"`
 	LastName      string    `gorm:"column:last_name" json:"last_name"`
 	AvatarURL     string    `gorm:"column:avatar_url" json:"avatar_url,omitempty"`
-	Role          string    `gorm:"column:role;type:varchar(20);default:'user';not null" json:"role"`
+	Language      string    `gorm:"column:language;type:varchar(10);default:'fr'" json:"language"`
+	Role          UserRole  `gorm:"column:role;type:user_role_enum;default:'user';not null" json:"role"`
 	EmailVerified bool      `gorm:"column:email_verified;default:false" json:"email_verified"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/api/auth-service/src/utils/jwt.go
+++ b/api/auth-service/src/utils/jwt.go
@@ -67,46 +67,47 @@ func getJWTSecret() (string, error) {
 }
 
 // GenerateTokenPair generates access and refresh token pair for a user
-func GenerateTokenPair(userID uint) (*TokenPair, error) {
-	// Get JWT secret from environment
+func GenerateTokenPair(userID uint, role string) (*TokenPair, error) {
 	secret, err := getJWTSecret()
 	if err != nil {
 		return nil, err
 	}
 
-	// Get refresh secret (fallback to main secret if not set)
 	refreshSecret := os.Getenv("JWT_REFRESH_SECRET")
 	if refreshSecret == "" {
 		refreshSecret = secret
 	}
 
+	if role == "" {
+		role = "user"
+	}
+
 	now := time.Now()
 	userIDStr := fmt.Sprintf("%d", userID)
 
-	// Get TTL from environment
 	accessTTL := GetDurationFromEnv("JWT_ACCESS_TTL", 15*time.Minute)
 	refreshTTL := GetDurationFromEnv("JWT_REFRESH_TTL", 7*24*time.Hour)
 
-	// Generate access token (short-lived)
 	accessClaims := jwt.MapClaims{
 		"sub":   userIDStr,
 		"iat":   now.Unix(),
 		"nbf":   now.Unix(),
 		"exp":   now.Add(accessTTL).Unix(),
 		"scope": "access",
+		"role":  role,
 	}
 	accessToken, err := SignToken(accessClaims, secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign access token: %w", err)
 	}
 
-	// Generate refresh token (long-lived)
 	refreshClaims := jwt.MapClaims{
 		"sub":   userIDStr,
 		"iat":   now.Unix(),
 		"nbf":   now.Unix(),
 		"exp":   now.Add(refreshTTL).Unix(),
 		"scope": "refresh",
+		"role":  role,
 	}
 	refreshToken, err := SignToken(refreshClaims, refreshSecret)
 	if err != nil {

--- a/api/gateway/src/main.go
+++ b/api/gateway/src/main.go
@@ -60,6 +60,7 @@ func main() {
 	routes.SetupLibraryRoutes(r)
 	routes.SetupTorrentRoutes(r)
 	routes.SetupCommentRoutes(r)
+	routes.SetupAdminRoutes(r)
 
 	log.Printf("Gateway starting on port %s", cfg.Port)
 	log.Fatal(http.ListenAndServe(":"+cfg.Port, r))

--- a/api/gateway/src/middleware/admin.go
+++ b/api/gateway/src/middleware/admin.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminMiddleware rejects requests from non-admin users.
+// Must be chained after JWTMiddleware.
+func AdminMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role, _ := c.Get(CtxUserRoleKey)
+		if role != "admin" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden: admin access required"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/api/gateway/src/middleware/jwt.go
+++ b/api/gateway/src/middleware/jwt.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	CtxUserIDKey = "userID"
+	CtxUserIDKey   = "userID"
+	CtxUserRoleKey = "userRole"
 )
 
 // JWTMiddleware validates JWT tokens and sets user context
@@ -54,11 +55,16 @@ func JWTMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// Extract common identifiers
 		if sub, ok := claims["sub"].(string); ok && sub != "" {
 			c.Set(CtxUserIDKey, sub)
 		} else {
 			log.Printf("[JWT] no valid 'sub' claim found in token")
+		}
+
+		if role, ok := claims["role"].(string); ok && role != "" {
+			c.Set(CtxUserRoleKey, role)
+		} else {
+			c.Set(CtxUserRoleKey, "user")
 		}
 
 		c.Next()

--- a/api/gateway/src/proxy/proxy.go
+++ b/api/gateway/src/proxy/proxy.go
@@ -116,6 +116,12 @@ func copyHeaders(c *gin.Context, req *http.Request) {
 		}
 	}
 
+	if v, ok := c.Get(middleware.CtxUserRoleKey); ok {
+		if s, ok := v.(string); ok && s != "" {
+			req.Header.Set("X-User-Role", s)
+		}
+	}
+
 	if token := utils.ExtractToken(c); token != "" {
 		req.Header.Set("X-JWT-Token", token)
 	}

--- a/api/gateway/src/routes/admin.go
+++ b/api/gateway/src/routes/admin.go
@@ -12,6 +12,7 @@ func SetupAdminRoutes(r *gin.Engine) {
 	admin.Use(middleware.JWTMiddleware())
 	admin.Use(middleware.AdminMiddleware())
 	{
+		admin.GET("/stats", proxy.ProxyRequest("torrent", "/api/v1/admin/stats"))
 		admin.GET("/users", proxy.ProxyRequest("user", "/api/v1/admin/users"))
 		admin.GET("/films", proxy.ProxyRequest("torrent", "/api/v1/admin/films"))
 		admin.DELETE("/films/:id", proxy.ProxyRequest("torrent", "/api/v1/admin/films/:id"))

--- a/api/gateway/src/routes/admin.go
+++ b/api/gateway/src/routes/admin.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"gateway/src/middleware"
+	"gateway/src/proxy"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SetupAdminRoutes(r *gin.Engine) {
+	admin := r.Group("/api/v1/admin")
+	admin.Use(middleware.JWTMiddleware())
+	admin.Use(middleware.AdminMiddleware())
+	{
+		admin.GET("/users", proxy.ProxyRequest("user", "/api/v1/admin/users"))
+		admin.GET("/films", proxy.ProxyRequest("torrent", "/api/v1/admin/films"))
+		admin.DELETE("/films/:id", proxy.ProxyRequest("torrent", "/api/v1/admin/films/:id"))
+		admin.POST("/films/:id/download", proxy.ProxyRequest("torrent", "/api/v1/admin/films/:id/download"))
+	}
+}

--- a/api/gateway/src/routes/torrent.go
+++ b/api/gateway/src/routes/torrent.go
@@ -25,6 +25,8 @@ func SetupTorrentRoutes(r *gin.Engine) {
 	movies.Use(middleware.JWTMiddleware())
 	{
 		movies.GET("/:id/watched", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/watched"))
+		movies.GET("/:id/progress", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/progress"))
+		movies.PUT("/:id/progress", proxy.ProxyRequest("torrent", "/api/v1/movies/:id/progress"))
 	}
 
 	subtitle := r.Group("/api/v1/subtitle")

--- a/api/torrent-service/src/conf/db.go
+++ b/api/torrent-service/src/conf/db.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 var DB *gorm.DB
@@ -22,7 +24,17 @@ func InitDB() {
 	)
 
 	var err error
-	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	gormLogger := logger.New(
+		log.Default(),
+		logger.Config{
+			SlowThreshold:             200 * time.Millisecond,
+			LogLevel:                  logger.Warn,
+			IgnoreRecordNotFoundError: true,
+		},
+	)
+	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: gormLogger,
+	})
 	if err != nil {
 		log.Fatal("Failed to connect to database:", err)
 	}

--- a/api/torrent-service/src/handlers/admin_films.go
+++ b/api/torrent-service/src/handlers/admin_films.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"torrent-service/src/services"
+	"torrent-service/src/utils"
+)
+
+// AdminListFilmsHandler handles GET /api/v1/admin/films
+func AdminListFilmsHandler(c *gin.Context) {
+	limit, offset := parsePagination(c)
+
+	films, total, err := services.ListAdminFilms(limit, offset)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to fetch films: "+err.Error())
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{
+		"films": films,
+		"pagination": gin.H{
+			"total":  total,
+			"limit":  limit,
+			"offset": offset,
+		},
+	})
+}
+
+// AdminDeleteFilmHandler handles DELETE /api/v1/admin/films/:id
+func AdminDeleteFilmHandler(c *gin.Context) {
+	id, err := parseTorrentID(c)
+	if err != nil {
+		utils.RespondError(c, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	if err := services.DeleteAdminFilm(id); err != nil {
+		if err.Error() == "not found" {
+			utils.RespondError(c, http.StatusNotFound, "film not found")
+			return
+		}
+		utils.RespondError(c, http.StatusInternalServerError, "failed to delete film: "+err.Error())
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"message": "film deleted successfully"})
+}
+
+// AdminReDownloadFilmHandler handles POST /api/v1/admin/films/:id/download
+func AdminReDownloadFilmHandler(c *gin.Context) {
+	id, err := parseTorrentID(c)
+	if err != nil {
+		utils.RespondError(c, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	infoHash, err := services.ReDownloadFilm(id)
+	if err != nil {
+		if err.Error() == "not found" {
+			utils.RespondError(c, http.StatusNotFound, "film not found")
+			return
+		}
+		utils.RespondError(c, http.StatusBadRequest, "failed to re-trigger download: "+err.Error())
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusAccepted, gin.H{
+		"info_hash": infoHash,
+		"status":    "downloading",
+		"message":   "torrent re-download triggered",
+	})
+}
+
+func parseTorrentID(c *gin.Context) (uint, error) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		return 0, err
+	}
+	return uint(id), nil
+}
+
+func parsePagination(c *gin.Context) (int, int) {
+	limit := 20
+	offset := 0
+	if l, err := strconv.Atoi(c.DefaultQuery("limit", "20")); err == nil && l > 0 {
+		limit = l
+	}
+	if o, err := strconv.Atoi(c.DefaultQuery("offset", "0")); err == nil && o >= 0 {
+		offset = o
+	}
+	return limit, offset
+}

--- a/api/torrent-service/src/handlers/admin_stats.go
+++ b/api/torrent-service/src/handlers/admin_stats.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"torrent-service/src/services"
+	"torrent-service/src/utils"
+)
+
+func AdminStatsHandler(c *gin.Context) {
+	stats, err := services.GetAdminStats()
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to fetch stats: "+err.Error())
+		return
+	}
+	utils.RespondSuccess(c, http.StatusOK, stats)
+}

--- a/api/torrent-service/src/handlers/progress.go
+++ b/api/torrent-service/src/handlers/progress.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"torrent-service/src/services"
+	"torrent-service/src/utils"
+)
+
+// GetProgressHandler handles GET /api/v1/movies/:id/progress
+func GetProgressHandler(c *gin.Context) {
+	userID, ok := userIDFromHeader(c)
+	if !ok {
+		utils.RespondError(c, http.StatusUnauthorized, "missing or invalid X-User-ID")
+		return
+	}
+
+	movieID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || movieID <= 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
+		return
+	}
+
+	sec, err := services.GetProgress(userID, movieID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"progress_sec": sec})
+}
+
+// SaveProgressHandler handles PUT /api/v1/movies/:id/progress
+func SaveProgressHandler(c *gin.Context) {
+	userID, ok := userIDFromHeader(c)
+	if !ok {
+		utils.RespondError(c, http.StatusUnauthorized, "missing or invalid X-User-ID")
+		return
+	}
+
+	movieID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || movieID <= 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
+		return
+	}
+
+	var body struct {
+		ProgressSec int `json:"progress_sec"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.ProgressSec < 0 {
+		utils.RespondError(c, http.StatusBadRequest, "invalid progress_sec")
+		return
+	}
+
+	if err := services.SaveProgress(userID, movieID, body.ProgressSec); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"progress_sec": body.ProgressSec})
+}

--- a/api/torrent-service/src/handlers/progress.go
+++ b/api/torrent-service/src/handlers/progress.go
@@ -11,6 +11,7 @@ import (
 )
 
 // GetProgressHandler handles GET /api/v1/movies/:id/progress
+// :id is the TMDB movie ID.
 func GetProgressHandler(c *gin.Context) {
 	userID, ok := userIDFromHeader(c)
 	if !ok {
@@ -18,13 +19,19 @@ func GetProgressHandler(c *gin.Context) {
 		return
 	}
 
-	movieID, err := strconv.Atoi(c.Param("id"))
-	if err != nil || movieID <= 0 {
+	tmdbID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || tmdbID <= 0 {
 		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
 		return
 	}
 
-	sec, err := services.GetProgress(userID, movieID)
+	localID, err := services.ResolveLocalMovieID(tmdbID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "could not resolve movie")
+		return
+	}
+
+	sec, err := services.GetProgress(userID, localID)
 	if err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "database error")
 		return
@@ -34,6 +41,7 @@ func GetProgressHandler(c *gin.Context) {
 }
 
 // SaveProgressHandler handles PUT /api/v1/movies/:id/progress
+// :id is the TMDB movie ID.
 func SaveProgressHandler(c *gin.Context) {
 	userID, ok := userIDFromHeader(c)
 	if !ok {
@@ -41,8 +49,8 @@ func SaveProgressHandler(c *gin.Context) {
 		return
 	}
 
-	movieID, err := strconv.Atoi(c.Param("id"))
-	if err != nil || movieID <= 0 {
+	tmdbID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || tmdbID <= 0 {
 		utils.RespondError(c, http.StatusBadRequest, "invalid movie id")
 		return
 	}
@@ -55,7 +63,13 @@ func SaveProgressHandler(c *gin.Context) {
 		return
 	}
 
-	if err := services.SaveProgress(userID, movieID, body.ProgressSec); err != nil {
+	localID, err := services.ResolveLocalMovieID(tmdbID)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "could not resolve movie")
+		return
+	}
+
+	if err := services.SaveProgress(userID, localID, body.ProgressSec); err != nil {
 		utils.RespondError(c, http.StatusInternalServerError, "database error")
 		return
 	}

--- a/api/torrent-service/src/handlers/status.go
+++ b/api/torrent-service/src/handlers/status.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -21,7 +22,7 @@ func StatusHandler(c *gin.Context) {
 
 	record, err := services.GetRecord(hash)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			utils.RespondError(c, http.StatusNotFound, "torrent not found")
 		} else {
 			utils.RespondError(c, http.StatusInternalServerError, err.Error())

--- a/api/torrent-service/src/handlers/status.go
+++ b/api/torrent-service/src/handlers/status.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -12,7 +13,7 @@ import (
 )
 
 func StatusHandler(c *gin.Context) {
-	hash := c.Param("id")
+	hash := strings.ToLower(c.Param("id"))
 	if hash == "" {
 		utils.RespondError(c, http.StatusBadRequest, "missing info hash")
 		return

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -45,11 +45,12 @@ func StreamHandler(c *gin.Context) {
 		return
 	case models.StatusError:
 		log.Printf("torrent %s failed: %s", hash, record.ErrorMsg)
-		utils.RespondError(c, http.StatusServiceUnavailable, "torrent processing failed")
+		utils.RespondError(c, http.StatusServiceUnavailable, record.ErrorMsg)
 		return
 	}
 
-	if userID, ok := userIDFromHeader(c); ok && record.MovieID > 0 {
+	userID, _ := userIDFromHeader(c)
+	if userID > 0 && record.MovieID > 0 {
 		services.RecordWatch(userID, record.MovieID) //nolint:errcheck
 	}
 
@@ -60,13 +61,9 @@ func StreamHandler(c *gin.Context) {
 		return
 	}
 
+	// Bug 1 fix: single NeedsTranscoding check (duplicate block removed).
 	if services.NeedsTranscoding(result.FileName) {
-		serveTranscoded(c, result)
-		return
-	}
-
-	if services.NeedsTranscoding(result.FileName) {
-		serveTranscoded(c, result)
+		serveTranscoded(c, result, userID, hash)
 		return
 	}
 
@@ -77,7 +74,7 @@ func StreamHandler(c *gin.Context) {
 	http.ServeContent(c.Writer, c.Request, result.FileName, time.Time{}, result.Reader)
 }
 
-func serveTranscoded(c *gin.Context, result services.ReaderResult) {
+func serveTranscoded(c *gin.Context, result services.ReaderResult, userID int, infoHash string) {
 	var codecInfo *services.CodecInfo
 	if result.FilePath != "" {
 		codecInfo, _ = services.ProbeCodecs(result.FilePath)
@@ -85,13 +82,16 @@ func serveTranscoded(c *gin.Context, result services.ReaderResult) {
 
 	job, err := services.StartTranscode(result.Reader, codecInfo)
 	if err != nil {
-		utils.RespondError(c, http.StatusInternalServerError, "transcoding error: "+err.Error())
+		// Bug 2 fix: single RespondError call (log first, then respond once).
 		log.Printf("transcoding error for %s: %v", result.FileName, err)
-		utils.RespondError(c, http.StatusInternalServerError, "transcoding failed")
+		utils.RespondError(c, http.StatusInternalServerError, "transcoding error: "+err.Error())
 		return
 	}
-	defer job.Cmd.Wait()
-	defer job.Reader.Close()
+	// Bug 3 fix: session ties ffmpeg lifecycle to the request context.
+	// Release runs first (LIFO), killing ffmpeg, then Wait collects exit status.
+	defer services.Sessions.Release(userID, infoHash)
+	defer job.Cmd.Wait() //nolint:errcheck
+	services.Sessions.Acquire(userID, infoHash, job, c.Request.Context())
 
 	c.Header("Content-Type", job.ContentType)
 	c.Header("Cache-Control", "no-cache")

--- a/api/torrent-service/src/handlers/stream.go
+++ b/api/torrent-service/src/handlers/stream.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"mime"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -26,7 +27,7 @@ func init() {
 }
 
 func StreamHandler(c *gin.Context) {
-	hash := c.Param("id")
+	hash := strings.ToLower(c.Param("id"))
 	if hash == "" {
 		utils.RespondError(c, http.StatusBadRequest, "missing info hash")
 		return

--- a/api/torrent-service/src/main.go
+++ b/api/torrent-service/src/main.go
@@ -9,6 +9,7 @@ import (
 
 	"torrent-service/src/conf"
 	"torrent-service/src/handlers"
+	"torrent-service/src/middleware"
 	"torrent-service/src/services"
 	"torrent-service/src/utils"
 )
@@ -40,6 +41,14 @@ func main() {
 		api.GET("/subtitle/:id", func(c *gin.Context) {
 			utils.RespondError(c, http.StatusNotImplemented, "subtitles not yet implemented")
 		})
+
+		admin := api.Group("/admin")
+		admin.Use(middleware.AdminMiddleware())
+		{
+			admin.GET("/films", handlers.AdminListFilmsHandler)
+			admin.DELETE("/films/:id", handlers.AdminDeleteFilmHandler)
+			admin.POST("/films/:id/download", handlers.AdminReDownloadFilmHandler)
+		}
 	}
 
 	port := os.Getenv("PORT")

--- a/api/torrent-service/src/main.go
+++ b/api/torrent-service/src/main.go
@@ -35,6 +35,8 @@ func main() {
 		}
 		api.GET("/stream/:id", handlers.StreamHandler)
 		api.GET("/movies/:id/watched", handlers.WatchedHandler)
+		api.GET("/movies/:id/progress", handlers.GetProgressHandler)
+		api.PUT("/movies/:id/progress", handlers.SaveProgressHandler)
 		api.GET("/subtitle/:id", func(c *gin.Context) {
 			utils.RespondError(c, http.StatusNotImplemented, "subtitles not yet implemented")
 		})

--- a/api/torrent-service/src/main.go
+++ b/api/torrent-service/src/main.go
@@ -45,6 +45,7 @@ func main() {
 		admin := api.Group("/admin")
 		admin.Use(middleware.AdminMiddleware())
 		{
+			admin.GET("/stats", handlers.AdminStatsHandler)
 			admin.GET("/films", handlers.AdminListFilmsHandler)
 			admin.DELETE("/films/:id", handlers.AdminDeleteFilmHandler)
 			admin.POST("/films/:id/download", handlers.AdminReDownloadFilmHandler)

--- a/api/torrent-service/src/middleware/admin.go
+++ b/api/torrent-service/src/middleware/admin.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"torrent-service/src/utils"
+)
+
+// AdminMiddleware rejects requests whose X-User-Role header is not "admin".
+// Must be placed after any auth middleware that sets X-User-ID.
+func AdminMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("X-User-Role") != "admin" {
+			utils.RespondError(c, http.StatusForbidden, "forbidden: admin access required")
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/api/torrent-service/src/services/admin.go
+++ b/api/torrent-service/src/services/admin.go
@@ -15,22 +15,23 @@ import (
 
 // AdminFilmRow is the result of the admin films list query.
 type AdminFilmRow struct {
-	ID           uint   `json:"id"`
-	MovieID      int    `json:"movie_id"`
-	TmdbID       int    `json:"tmdb_id"`
-	InfoHash     string `json:"info_hash"`
-	Status       string `json:"status"`
-	FilePath     string `json:"file_path"`
-	FileSize     int64  `json:"file_size"`
-	Downloaded   int64  `json:"downloaded"`
-	Progress     float64 `json:"progress"`
-	Title        string `json:"title"`
-	PosterPath   string `json:"poster_path"`
-	CreatedAt    string `json:"created_at"`
-	WatchersCount int64  `json:"watchers_count"`
+	ID            uint    `json:"id"`
+	MovieID       int     `json:"movie_id"`
+	TmdbID        int     `json:"tmdb_id"`
+	InfoHash      string  `json:"info_hash"`
+	Status        string  `json:"status"`
+	FilePath      string  `json:"file_path"`
+	FileSize      int64   `json:"file_size"`
+	Downloaded    int64   `json:"downloaded"`
+	Progress      float64 `json:"progress"`
+	Title         string  `json:"title"`
+	PosterPath    string  `json:"poster_path"`
+	Language      string  `json:"language"`
+	CreatedAt     string  `json:"created_at"`
+	WatchersCount int64   `json:"watchers_count"`
 	// comma-separated user IDs — parsed by the handler
 	watcherIDsRaw string
-	WatcherIDs    []int  `json:"watcher_ids"`
+	WatcherIDs    []int `json:"watcher_ids"`
 }
 
 // ListAdminFilms returns all torrent records with movie metadata and watcher info.
@@ -52,6 +53,7 @@ func ListAdminFilms(limit, offset int) ([]AdminFilmRow, int64, error) {
 		Progress      float64 `gorm:"column:progress"`
 		Title         string  `gorm:"column:title"`
 		PosterPath    string  `gorm:"column:poster_path"`
+		Language      string  `gorm:"column:language"`
 		CreatedAt     string  `gorm:"column:created_at"`
 		WatchersCount int64   `gorm:"column:watchers_count"`
 		WatcherIDsRaw string  `gorm:"column:watcher_ids"`
@@ -71,13 +73,14 @@ func ListAdminFilms(limit, offset int) ([]AdminFilmRow, int64, error) {
 			t.progress,
 			COALESCE(m.title, '')           AS title,
 			COALESCE(m.poster_path, '')     AS poster_path,
+			COALESCE(m.language, '')        AS language,
 			to_char(t.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
 			COUNT(DISTINCT wh.user_id)      AS watchers_count,
 			COALESCE(string_agg(DISTINCT wh.user_id::text, ','), '') AS watcher_ids
 		FROM torrents t
 		LEFT JOIN movies m  ON m.id = t.movie_id
 		LEFT JOIN watch_history wh ON wh.movie_id = t.movie_id
-		GROUP BY t.id, m.tmdb_id, m.title, m.poster_path
+		GROUP BY t.id, m.tmdb_id, m.title, m.poster_path, m.language
 		ORDER BY t.created_at DESC
 		LIMIT ? OFFSET ?
 	`, limit, offset).Scan(&rows).Error
@@ -99,6 +102,7 @@ func ListAdminFilms(limit, offset int) ([]AdminFilmRow, int64, error) {
 			Progress:      r.Progress,
 			Title:         r.Title,
 			PosterPath:    r.PosterPath,
+			Language:      r.Language,
 			CreatedAt:     r.CreatedAt,
 			WatchersCount: r.WatchersCount,
 			WatcherIDs:    parseIntCSV(r.WatcherIDsRaw),

--- a/api/torrent-service/src/services/admin.go
+++ b/api/torrent-service/src/services/admin.go
@@ -1,0 +1,216 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/anacrolix/torrent"
+	"gorm.io/gorm"
+
+	"torrent-service/src/conf"
+	"torrent-service/src/models"
+)
+
+// AdminFilmRow is the result of the admin films list query.
+type AdminFilmRow struct {
+	ID           uint   `json:"id"`
+	MovieID      int    `json:"movie_id"`
+	TmdbID       int    `json:"tmdb_id"`
+	InfoHash     string `json:"info_hash"`
+	Status       string `json:"status"`
+	FilePath     string `json:"file_path"`
+	FileSize     int64  `json:"file_size"`
+	Downloaded   int64  `json:"downloaded"`
+	Progress     float64 `json:"progress"`
+	Title        string `json:"title"`
+	PosterPath   string `json:"poster_path"`
+	CreatedAt    string `json:"created_at"`
+	WatchersCount int64  `json:"watchers_count"`
+	// comma-separated user IDs — parsed by the handler
+	watcherIDsRaw string
+	WatcherIDs    []int  `json:"watcher_ids"`
+}
+
+// ListAdminFilms returns all torrent records with movie metadata and watcher info.
+func ListAdminFilms(limit, offset int) ([]AdminFilmRow, int64, error) {
+	var total int64
+	if err := conf.DB.Table("torrents").Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("count: %w", err)
+	}
+
+	type rawRow struct {
+		ID            uint    `gorm:"column:id"`
+		MovieID       int     `gorm:"column:movie_id"`
+		TmdbID        int     `gorm:"column:tmdb_id"`
+		InfoHash      string  `gorm:"column:info_hash"`
+		Status        string  `gorm:"column:status"`
+		FilePath      string  `gorm:"column:file_path"`
+		FileSize      int64   `gorm:"column:file_size"`
+		Downloaded    int64   `gorm:"column:downloaded"`
+		Progress      float64 `gorm:"column:progress"`
+		Title         string  `gorm:"column:title"`
+		PosterPath    string  `gorm:"column:poster_path"`
+		CreatedAt     string  `gorm:"column:created_at"`
+		WatchersCount int64   `gorm:"column:watchers_count"`
+		WatcherIDsRaw string  `gorm:"column:watcher_ids"`
+	}
+
+	var rows []rawRow
+	err := conf.DB.Raw(`
+		SELECT
+			t.id,
+			t.movie_id,
+			COALESCE(m.tmdb_id, 0)         AS tmdb_id,
+			t.info_hash,
+			t.status,
+			COALESCE(t.file_path, '')       AS file_path,
+			t.file_size,
+			t.downloaded,
+			t.progress,
+			COALESCE(m.title, '')           AS title,
+			COALESCE(m.poster_path, '')     AS poster_path,
+			to_char(t.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+			COUNT(DISTINCT wh.user_id)      AS watchers_count,
+			COALESCE(string_agg(DISTINCT wh.user_id::text, ','), '') AS watcher_ids
+		FROM torrents t
+		LEFT JOIN movies m  ON m.id = t.movie_id
+		LEFT JOIN watch_history wh ON wh.movie_id = t.movie_id
+		GROUP BY t.id, m.tmdb_id, m.title, m.poster_path
+		ORDER BY t.created_at DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("query: %w", err)
+	}
+
+	result := make([]AdminFilmRow, 0, len(rows))
+	for _, r := range rows {
+		row := AdminFilmRow{
+			ID:            r.ID,
+			MovieID:       r.MovieID,
+			TmdbID:        r.TmdbID,
+			InfoHash:      r.InfoHash,
+			Status:        r.Status,
+			FilePath:      r.FilePath,
+			FileSize:      r.FileSize,
+			Downloaded:    r.Downloaded,
+			Progress:      r.Progress,
+			Title:         r.Title,
+			PosterPath:    r.PosterPath,
+			CreatedAt:     r.CreatedAt,
+			WatchersCount: r.WatchersCount,
+			WatcherIDs:    parseIntCSV(r.WatcherIDsRaw),
+		}
+		result = append(result, row)
+	}
+	return result, total, nil
+}
+
+// DeleteAdminFilm removes a torrent from disk and clears all related DB records.
+func DeleteAdminFilm(id uint) error {
+	var record models.TorrentRecord
+	if err := conf.DB.First(&record, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("not found")
+		}
+		return fmt.Errorf("db lookup: %w", err)
+	}
+
+	// Remove active torrent from client if still seeding/downloading.
+	if v, ok := activeTorrents.Load(record.InfoHash); ok {
+		if t, ok := v.(*torrent.Torrent); ok {
+			t.Drop()
+		}
+		activeTorrents.Delete(record.InfoHash)
+	}
+
+	// Remove files from disk (entire info-hash directory).
+	torrentDir := downloadDir() + "/" + record.InfoHash
+	if err := os.RemoveAll(torrentDir); err != nil && !os.IsNotExist(err) {
+		log.Printf("[admin] warning: failed to remove torrent dir %s: %v", torrentDir, err)
+	}
+
+	// Also attempt to remove by stored file_path directory as a fallback.
+	if record.FilePath != "" {
+		if err := os.RemoveAll(record.FilePath); err != nil && !os.IsNotExist(err) {
+			log.Printf("[admin] warning: failed to remove file %s: %v", record.FilePath, err)
+		}
+	}
+
+	// Clear watch_history for this movie.
+	conf.DB.Where("movie_id = ?", record.MovieID).Delete(&models.WatchHistory{})
+
+	// Delete the torrent record.
+	if err := conf.DB.Delete(&record).Error; err != nil {
+		return fmt.Errorf("db delete: %w", err)
+	}
+
+	log.Printf("[admin] deleted torrent %d (hash=%s)", id, record.InfoHash)
+	return nil
+}
+
+// ReDownloadFilm resets a torrent record to pending and re-queues it for download.
+func ReDownloadFilm(id uint) (string, error) {
+	var record models.TorrentRecord
+	if err := conf.DB.First(&record, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", fmt.Errorf("not found")
+		}
+		return "", fmt.Errorf("db lookup: %w", err)
+	}
+
+	if record.MagnetURI == "" {
+		return "", fmt.Errorf("no magnet URI stored for this record")
+	}
+
+	// Drop active torrent so StartDownload can re-add it.
+	activeTorrents.Delete(record.InfoHash)
+
+	// Reset to pending so findOrCreateRecord takes the retry path.
+	conf.DB.Model(&record).Updates(map[string]any{
+		"status":    models.StatusPending,
+		"error_msg": "",
+		"progress":  0,
+	})
+
+	// StartDownload expects the TMDB ID; look it up from movies table.
+	var tmdbID int
+	conf.DB.Raw("SELECT tmdb_id FROM movies WHERE id = ?", record.MovieID).Scan(&tmdbID)
+	if tmdbID == 0 {
+		tmdbID = record.MovieID // fallback: treat stored movie_id as tmdb_id
+	}
+
+	return StartDownload(record.MagnetURI, tmdbID)
+}
+
+// parseIntCSV splits a comma-separated string of integers into a slice.
+func parseIntCSV(s string) []int {
+	if s == "" {
+		return []int{}
+	}
+	var result []int
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			part := s[start:i]
+			if n := atoi(part); n > 0 {
+				result = append(result, n)
+			}
+			start = i + 1
+		}
+	}
+	return result
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/api/torrent-service/src/services/admin_stats.go
+++ b/api/torrent-service/src/services/admin_stats.go
@@ -1,0 +1,95 @@
+package services
+
+import (
+	"fmt"
+
+	"torrent-service/src/conf"
+)
+
+type AdminStats struct {
+	TotalUsers      int64            `json:"total_users"`
+	TotalFilms      int64            `json:"total_films"`
+	TotalWatches    int64            `json:"total_watches"`
+	FilmsByStatus   []StatusCount    `json:"films_by_status"`
+	WatchesPerDay   []DayCount       `json:"watches_per_day"`
+	TopFilms        []TopFilm        `json:"top_films"`
+	RegistrationsPerMonth []MonthCount `json:"registrations_per_month"`
+}
+
+type StatusCount struct {
+	Status string `json:"status" gorm:"column:status"`
+	Count  int64  `json:"count"  gorm:"column:count"`
+}
+
+type DayCount struct {
+	Day   string `json:"day"   gorm:"column:day"`
+	Count int64  `json:"count" gorm:"column:count"`
+}
+
+type MonthCount struct {
+	Month string `json:"month" gorm:"column:month"`
+	Count int64  `json:"count" gorm:"column:count"`
+}
+
+type TopFilm struct {
+	Title  string `json:"title"  gorm:"column:title"`
+	Watches int64 `json:"watches" gorm:"column:watches"`
+}
+
+func GetAdminStats() (AdminStats, error) {
+	var stats AdminStats
+
+	if err := conf.DB.Raw("SELECT COUNT(*) FROM users").Scan(&stats.TotalUsers).Error; err != nil {
+		return stats, fmt.Errorf("count users: %w", err)
+	}
+
+	if err := conf.DB.Raw("SELECT COUNT(*) FROM torrents").Scan(&stats.TotalFilms).Error; err != nil {
+		return stats, fmt.Errorf("count films: %w", err)
+	}
+
+	if err := conf.DB.Raw("SELECT COUNT(*) FROM watch_history").Scan(&stats.TotalWatches).Error; err != nil {
+		return stats, fmt.Errorf("count watches: %w", err)
+	}
+
+	if err := conf.DB.Raw(`
+		SELECT status, COUNT(*) AS count
+		FROM torrents
+		GROUP BY status
+	`).Scan(&stats.FilmsByStatus).Error; err != nil {
+		return stats, fmt.Errorf("films by status: %w", err)
+	}
+
+	if err := conf.DB.Raw(`
+		SELECT to_char(watched_at, 'YYYY-MM-DD') AS day, COUNT(*) AS count
+		FROM watch_history
+		WHERE watched_at >= NOW() - INTERVAL '30 days'
+		GROUP BY to_char(watched_at, 'YYYY-MM-DD')
+		ORDER BY day ASC
+	`).Scan(&stats.WatchesPerDay).Error; err != nil {
+		return stats, fmt.Errorf("watches per day: %w", err)
+	}
+
+	if err := conf.DB.Raw(`
+		SELECT COALESCE(m.title, t.info_hash) AS title, COUNT(wh.id) AS watches
+		FROM watch_history wh
+		LEFT JOIN torrents t ON t.movie_id = wh.movie_id
+		LEFT JOIN movies m ON m.id = wh.movie_id
+		GROUP BY COALESCE(m.title, t.info_hash)
+		ORDER BY watches DESC
+		LIMIT 5
+	`).Scan(&stats.TopFilms).Error; err != nil {
+		return stats, fmt.Errorf("top films: %w", err)
+	}
+
+	if err := conf.DB.Raw(`
+		SELECT to_char(created_at, 'YYYY-MM') AS month, COUNT(*) AS count
+		FROM users
+		WHERE created_at >= NOW() - INTERVAL '6 months'
+		GROUP BY to_char(created_at, 'YYYY-MM')
+		ORDER BY month ASC
+	`).Scan(&stats.RegistrationsPerMonth).Error; err != nil {
+		return stats, fmt.Errorf("registrations per month: %w", err)
+	}
+
+	return stats, nil
+}

--- a/api/torrent-service/src/services/download.go
+++ b/api/torrent-service/src/services/download.go
@@ -41,6 +41,11 @@ func StartDownload(magnetURI string, movieID int) (string, error) {
 		return "", err
 	}
 
+	// File is already on disk — stream directly, no need to re-seed.
+	if record.Status == models.StatusReady {
+		return infoHash, nil
+	}
+
 	t, err := addToClient(magnetURI)
 	if err != nil {
 		conf.DB.Model(record).Updates(map[string]any{

--- a/api/torrent-service/src/services/download.go
+++ b/api/torrent-service/src/services/download.go
@@ -60,6 +60,12 @@ func StartDownload(magnetURI string, movieID int) (string, error) {
 	return infoHash, nil
 }
 
+// ResolveLocalMovieID returns the local movies.id for a TMDB movie ID,
+// inserting a placeholder row if the movie has not been cached yet.
+func ResolveLocalMovieID(tmdbID int) (int, error) {
+	return resolveLocalMovieID(tmdbID)
+}
+
 func resolveLocalMovieID(tmdbID int) (int, error) {
 	var localID int
 	conf.DB.Raw("SELECT id FROM movies WHERE tmdb_id = ?", tmdbID).Scan(&localID)

--- a/api/torrent-service/src/services/reader.go
+++ b/api/torrent-service/src/services/reader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,9 +59,19 @@ func readerFromActiveTorrent(t *torrent.Torrent) (ReaderResult, error) {
 	}
 
 	r := f.NewReader()
-	r.SetReadahead(5 << 20) // 5 MiB readahead for smooth streaming
+	r.SetReadahead(readaheadBytes())
 	filePath := downloadDir() + "/" + strings.ToLower(t.InfoHash().HexString()) + "/" + f.DisplayPath()
 	return ReaderResult{Reader: r, Size: f.Length(), FileName: f.DisplayPath(), FilePath: filePath}, nil
+}
+
+// readaheadBytes reads STREAM_BUFFER_SIZE (MiB) from the environment, defaulting to 5 MiB.
+func readaheadBytes() int64 {
+	if s := os.Getenv("STREAM_BUFFER_SIZE"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n > 0 {
+			return n << 20
+		}
+	}
+	return 5 << 20
 }
 
 func readerFromDisk(infoHash string) (ReaderResult, error) {

--- a/api/torrent-service/src/services/reader.go
+++ b/api/torrent-service/src/services/reader.go
@@ -3,7 +3,9 @@ package services
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -83,9 +85,45 @@ func readerFromDisk(infoHash string) (ReaderResult, error) {
 		return ReaderResult{}, errors.New("torrent not ready")
 	}
 
-	f, err := os.Open(record.FilePath)
+	filePath := record.FilePath
+	if _, statErr := os.Stat(filePath); statErr != nil {
+		// Stored path is stale — scan the torrent directory for the largest file.
+		filePath = scanLargestFile(downloadDir() + "/" + infoHash)
+		if filePath == "" {
+			return ReaderResult{}, fmt.Errorf("open file: %w", statErr)
+		}
+		conf.DB.Model(record).Update("file_path", filePath)
+	}
+
+	f, err := os.Open(filePath)
 	if err != nil {
 		return ReaderResult{}, fmt.Errorf("open file: %w", err)
 	}
-	return ReaderResult{Reader: f, Size: record.FileSize, FileName: record.FilePath, FilePath: record.FilePath}, nil
+	info, _ := f.Stat()
+	size := record.FileSize
+	if info != nil && info.Size() > 0 {
+		size = info.Size()
+	}
+	return ReaderResult{Reader: f, Size: size, FileName: filepath.Base(filePath), FilePath: filePath}, nil
+}
+
+// scanLargestFile walks dir and returns the path of the largest file found.
+func scanLargestFile(dir string) string {
+	var best string
+	var bestSize int64
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.Size() > bestSize {
+			bestSize = info.Size()
+			best = path
+		}
+		return nil
+	})
+	return best
 }

--- a/api/torrent-service/src/services/services_test.go
+++ b/api/torrent-service/src/services/services_test.go
@@ -36,6 +36,11 @@ func setupTestDB(t *testing.T) {
 		created_at DATETIME,
 		updated_at DATETIME
 	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE movies (
+		id      INTEGER PRIMARY KEY AUTOINCREMENT,
+		tmdb_id INTEGER UNIQUE NOT NULL,
+		title   TEXT    NOT NULL
+	)`).Error)
 	conf.DB = db
 }
 

--- a/api/torrent-service/src/services/session_manager.go
+++ b/api/torrent-service/src/services/session_manager.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const sessionMaxIdle    = 2 * time.Minute
+const sessionGCInterval = 30 * time.Second
+
+// StreamSession holds the lifecycle context for one user's active stream.
+type StreamSession struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	job       *TranscodeJob
+	createdAt time.Time
+	mu        sync.Mutex
+}
+
+// StreamSessionManager tracks active streams keyed by "userID:infoHash".
+type StreamSessionManager struct {
+	mu       sync.Mutex
+	sessions map[string]*StreamSession
+}
+
+// Sessions is the process-wide session manager.
+var Sessions = newStreamSessionManager()
+
+func newStreamSessionManager() *StreamSessionManager {
+	m := &StreamSessionManager{sessions: make(map[string]*StreamSession)}
+	go m.runGC()
+	return m
+}
+
+// Acquire registers a new stream session for (userID, infoHash), replacing any
+// existing one. The ffmpeg process is killed automatically when reqCtx is done
+// (client disconnect) or when Release is called.
+func (m *StreamSessionManager) Acquire(userID int, infoHash string, job *TranscodeJob, reqCtx context.Context) *StreamSession {
+	key := fmt.Sprintf("%d:%s", userID, infoHash)
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &StreamSession{ctx: ctx, cancel: cancel, job: job, createdAt: time.Now()}
+
+	m.mu.Lock()
+	if old, ok := m.sessions[key]; ok {
+		old.kill()
+	}
+	m.sessions[key] = s
+	m.mu.Unlock()
+
+	go func() {
+		select {
+		case <-reqCtx.Done():
+			m.remove(key)
+		case <-ctx.Done():
+		}
+	}()
+
+	return s
+}
+
+// Release removes the session and kills the associated ffmpeg process.
+func (m *StreamSessionManager) Release(userID int, infoHash string) {
+	m.remove(fmt.Sprintf("%d:%s", userID, infoHash))
+}
+
+func (m *StreamSessionManager) remove(key string) {
+	m.mu.Lock()
+	s, ok := m.sessions[key]
+	if ok {
+		delete(m.sessions, key)
+	}
+	m.mu.Unlock()
+	if ok {
+		s.kill()
+	}
+}
+
+func (m *StreamSessionManager) runGC() {
+	t := time.NewTicker(sessionGCInterval)
+	defer t.Stop()
+	for range t.C {
+		now := time.Now()
+		var stale []string
+		m.mu.Lock()
+		for k, s := range m.sessions {
+			if now.Sub(s.createdAt) > sessionMaxIdle {
+				stale = append(stale, k)
+			}
+		}
+		for _, k := range stale {
+			if s, ok := m.sessions[k]; ok {
+				delete(m.sessions, k)
+				go s.kill()
+			}
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (s *StreamSession) kill() {
+	s.cancel()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.job == nil {
+		return
+	}
+	s.job.Reader.Close()
+	if s.job.Cmd != nil && s.job.Cmd.Process != nil {
+		s.job.Cmd.Process.Kill()
+	}
+	s.job = nil
+}

--- a/api/torrent-service/src/services/watch_history.go
+++ b/api/torrent-service/src/services/watch_history.go
@@ -28,3 +28,29 @@ func IsWatched(userID, movieID int) (bool, error) {
 		Count(&count).Error
 	return count > 0, err
 }
+
+// GetProgress returns the saved playback position in seconds for a user/movie pair.
+// Returns 0 if no record exists yet.
+func GetProgress(userID, movieID int) (int, error) {
+	var entry models.WatchHistory
+	err := conf.DB.
+		Where("user_id = ? AND movie_id = ?", userID, movieID).
+		First(&entry).Error
+	if err != nil {
+		return 0, nil // no record yet → start from beginning
+	}
+	return entry.ProgressSec, nil
+}
+
+// SaveProgress upserts the playback position in seconds for a user/movie pair.
+func SaveProgress(userID, movieID, progressSec int) error {
+	entry := models.WatchHistory{
+		UserID:    userID,
+		MovieID:   movieID,
+		WatchedAt: time.Now(),
+	}
+	return conf.DB.
+		Where(models.WatchHistory{UserID: userID, MovieID: movieID}).
+		Assign(models.WatchHistory{ProgressSec: progressSec, WatchedAt: entry.WatchedAt}).
+		FirstOrCreate(&entry).Error
+}

--- a/api/user-service/src/handlers/admin_users.go
+++ b/api/user-service/src/handlers/admin_users.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"user-service/src/conf"
+	"user-service/src/models"
+	"user-service/src/utils"
+)
+
+type adminUserRow struct {
+	ID              uint             `json:"id"`
+	Username        string           `json:"username"`
+	Email           string           `json:"email"`
+	FirstName       string           `json:"first_name"`
+	LastName        string           `json:"last_name"`
+	AvatarURL       string           `json:"avatar_url"`
+	Role            models.UserRole  `json:"role"`
+	EmailVerified   bool             `json:"email_verified"`
+	CreatedAt       time.Time        `json:"created_at"`
+	FilmsWatched    int64            `json:"films_watched"`
+	FilmsDownloaded int64            `json:"films_downloaded"`
+}
+
+// AdminListUsersHandler handles GET /api/v1/admin/users
+func AdminListUsersHandler(c *gin.Context) {
+	pagination := utils.ParsePaginationParams(c)
+
+	var total int64
+	if err := conf.DB.Table("users").Count(&total).Error; err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to count users")
+		return
+	}
+
+	var rows []adminUserRow
+	err := conf.DB.Raw(`
+		SELECT
+			u.id,
+			u.username,
+			u.email,
+			u.first_name,
+			u.last_name,
+			COALESCE(u.avatar_url, '') AS avatar_url,
+			u.role,
+			u.email_verified,
+			u.created_at,
+			COUNT(DISTINCT wh.movie_id) AS films_watched,
+			COUNT(DISTINCT CASE WHEN t.status = 'ready' THEN wh.movie_id END) AS films_downloaded
+		FROM users u
+		LEFT JOIN watch_history wh ON wh.user_id = u.id
+		LEFT JOIN torrents t ON t.movie_id = wh.movie_id
+		GROUP BY u.id
+		ORDER BY u.created_at DESC
+		LIMIT ? OFFSET ?
+	`, pagination.Limit, pagination.Offset).Scan(&rows).Error
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, "failed to fetch users")
+		return
+	}
+
+	utils.RespondSuccess(c, http.StatusOK, gin.H{
+		"users":      rows,
+		"pagination": utils.NewPagination(total, pagination.Limit, pagination.Offset),
+	})
+}

--- a/api/user-service/src/main.go
+++ b/api/user-service/src/main.go
@@ -44,11 +44,18 @@ func main() {
 		protected.Use(middleware.AuthMiddleware())
 		{
 			protected.GET("", handlers.ListUsersHandler)
-		protected.GET("/profile", handlers.GetOwnProfileHandler)
+			protected.GET("/profile", handlers.GetOwnProfileHandler)
 			protected.PUT(profileByID, handlers.UpdateProfileHandler)
 			protected.DELETE(profileByID, handlers.DeleteProfileHandler)
 			protected.POST("/avatar", handlers.UploadAvatarHandler)
 		}
+	}
+
+	admin := r.Group("/api/v1/admin")
+	admin.Use(middleware.AuthMiddleware())
+	admin.Use(middleware.AdminMiddleware())
+	{
+		admin.GET("/users", handlers.AdminListUsersHandler)
 	}
 
 	log.Println("User service starting on port 8002")

--- a/api/user-service/src/middleware/admin.go
+++ b/api/user-service/src/middleware/admin.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"user-service/src/utils"
+)
+
+// AdminMiddleware rejects requests from non-admin users.
+// Must be chained after AuthMiddleware.
+func AdminMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role := c.GetHeader("X-User-Role")
+		if role != "admin" {
+			utils.RespondError(c, http.StatusForbidden, "forbidden: admin access required")
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/api/user-service/src/models/user.go
+++ b/api/user-service/src/models/user.go
@@ -2,6 +2,13 @@ package models
 
 import "time"
 
+type UserRole string
+
+const (
+	RoleUser  UserRole = "user"
+	RoleAdmin UserRole = "admin"
+)
+
 type User struct {
 	ID            uint      `gorm:"primaryKey;column:id" json:"id"`
 	Username      string    `gorm:"column:username;type:varchar(50);uniqueIndex;not null" json:"username"`
@@ -11,7 +18,7 @@ type User struct {
 	LastName      string    `gorm:"column:last_name" json:"last_name"`
 	AvatarURL     string    `gorm:"column:avatar_url" json:"avatar_url,omitempty"`
 	Language      string    `gorm:"column:language;type:varchar(10);default:'fr'" json:"language"`
-	Role          string    `gorm:"column:role;type:varchar(20);default:'user';not null" json:"role"`
+	Role          UserRole  `gorm:"column:role;type:user_role_enum;default:'user';not null" json:"role"`
 	EmailVerified bool      `gorm:"column:email_verified;default:false" json:"email_verified"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/api/user-service/src/models/user.go
+++ b/api/user-service/src/models/user.go
@@ -11,6 +11,7 @@ type User struct {
 	LastName      string    `gorm:"column:last_name" json:"last_name"`
 	AvatarURL     string    `gorm:"column:avatar_url" json:"avatar_url,omitempty"`
 	Language      string    `gorm:"column:language;type:varchar(10);default:'fr'" json:"language"`
+	Role          string    `gorm:"column:role;type:varchar(20);default:'user';not null" json:"role"`
 	EmailVerified bool      `gorm:"column:email_verified;default:false" json:"email_verified"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -251,6 +251,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - DAC_OVERRIDE
 
   comment-service:
     build:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-i18next": "^17.0.6",
+    "recharts": "^3.8.1",
     "server-only": "^0.0.1",
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
@@ -33,6 +34,9 @@
     "typescript": "^5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["msw", "sharp"]
+    "onlyBuiltDependencies": [
+      "msw",
+      "sharp"
+    ]
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-i18next:
         specifier: ^17.0.6
         version: 17.0.6(i18next@26.0.8(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.6)(react@19.2.4)(redux@5.0.1)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1242,12 +1245,29 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1347,6 +1367,33 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
@@ -1363,6 +1410,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -1554,6 +1604,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1566,6 +1660,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1657,6 +1754,9 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1672,6 +1772,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -1869,12 +1972,22 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.7:
+    resolution: {integrity: sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -2378,6 +2491,21 @@ packages:
       typescript:
         optional: true
 
+  react-is@19.2.6:
+    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2416,6 +2544,22 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2423,6 +2567,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2709,6 +2856,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
@@ -3986,9 +4136,25 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.7
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4069,6 +4235,30 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
@@ -4086,6 +4276,8 @@ snapshots:
       '@types/node': 20.19.39
 
   '@types/statuses@2.0.6': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -4251,11 +4443,51 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   dedent@1.7.2: {}
 
@@ -4322,6 +4554,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-toolkit@1.46.1: {}
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -4329,6 +4563,8 @@ snapshots:
   esprima@4.0.1: {}
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -4564,12 +4800,18 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.7: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   inherits@2.0.4: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -5033,6 +5275,17 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       typescript: 5.9.3
 
+  react-is@19.2.6: {}
+
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -5070,9 +5323,37 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.6)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.6
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5398,6 +5679,23 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   void-elements@3.1.0: {}
 

--- a/frontend/src/app/(auth)/logout/logout.tsx
+++ b/frontend/src/app/(auth)/logout/logout.tsx
@@ -1,18 +1,20 @@
 'use client'
 
-import { useTranslation } from 'react-i18next'
+import { useTransition } from 'react'
 import { logout } from '@/app/actions/auth'
 import { Button } from '@/components/ui/button'
-import {LogOut } from 'lucide-react'
+import { LogOut } from 'lucide-react'
 
 export default function LogoutButton() {
-  const { t } = useTranslation()
+  const [isPending, startTransition] = useTransition()
 
   return (
-    <form action={logout}>
-      <Button type="submit" className='bg-orange-400 hover:bg-orange-500'>
-        <LogOut className="size-8" />
-      </Button>
-    </form>
+    <Button
+      disabled={isPending}
+      onClick={() => startTransition(() => logout())}
+      className="bg-orange-400 hover:bg-orange-500"
+    >
+      <LogOut className="size-8" />
+    </Button>
   )
 }

--- a/frontend/src/app/(main)/admin/films/_components/FilmRow.tsx
+++ b/frontend/src/app/(main)/admin/films/_components/FilmRow.tsx
@@ -1,0 +1,113 @@
+'use client'
+import Link from 'next/link'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Loader2, Trash2, RefreshCw } from 'lucide-react'
+import { FilmStatusBadge } from './FilmStatusBadge'
+import type { AdminFilm } from '../hooks/useAdminFilms'
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '—'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let v = bytes
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(1)} ${units[i]}`
+}
+
+interface FilmRowProps {
+  film: AdminFilm
+  isActing: boolean
+  actionType: 'delete' | 'redownload' | null
+  onDelete: () => void
+  onReDownload: () => void
+}
+
+export function FilmRow({ film, isActing, actionType, onDelete, onReDownload }: FilmRowProps) {
+  const { t } = useTranslation()
+
+  return (
+    <tr className="border-b last:border-0 hover:bg-muted/40 transition-colors">
+      <td className="py-2.5 pr-4">
+        {film.tmdb_id ? (
+          <Link
+            href={`/movies/${film.tmdb_id}`}
+            className="font-medium leading-tight hover:underline hover:text-sidebar-primary"
+          >
+            {film.title || film.info_hash.slice(0, 12)}
+          </Link>
+        ) : (
+          <span className="font-medium leading-tight">{film.title || film.info_hash.slice(0, 12)}</span>
+        )}
+        {film.status === 'downloading' && (
+          <div className="mt-1 flex items-center gap-2">
+            <div className="h-1 w-24 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full bg-sidebar-primary transition-all"
+                style={{ width: `${Math.min(100, film.progress)}%` }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground">{film.progress.toFixed(0)}%</span>
+          </div>
+        )}
+      </td>
+
+      <td className="py-2.5 pr-4">
+        <span className="font-mono text-xs text-muted-foreground" title={film.info_hash}>
+          {film.info_hash.slice(0, 16)}…
+        </span>
+      </td>
+
+      <td className="py-2.5 pr-4">
+        {film.language ? (
+          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground uppercase tracking-wide">
+            {film.language}
+          </span>
+        ) : (
+          <span className="text-muted-foreground text-xs">—</span>
+        )}
+      </td>
+
+      <td className="py-2.5 pr-4">
+        <FilmStatusBadge status={film.status} />
+      </td>
+
+      <td className="py-2.5 pr-4 text-right tabular-nums text-muted-foreground">
+        {formatBytes(film.file_size)}
+      </td>
+
+      <td className="py-2.5 pr-4 text-right tabular-nums">
+        {film.watchers_count}
+      </td>
+
+      <td className="py-2.5 text-right">
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isActing}
+            onClick={onReDownload}
+            title={t('admin.action_redownload')}
+          >
+            {isActing && actionType === 'redownload'
+              ? <Loader2 className="size-3.5 animate-spin" />
+              : <RefreshCw className="size-3.5" />
+            }
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={isActing}
+            onClick={onDelete}
+            title={t('admin.action_delete')}
+          >
+            {isActing && actionType === 'delete'
+              ? <Loader2 className="size-3.5 animate-spin" />
+              : <Trash2 className="size-3.5" />
+            }
+          </Button>
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/frontend/src/app/(main)/admin/films/_components/FilmStatusBadge.tsx
+++ b/frontend/src/app/(main)/admin/films/_components/FilmStatusBadge.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { useTranslation } from 'react-i18next'
+
+const STATUS_CLASSES: Record<string, string> = {
+  ready:       'bg-green-500/15 text-green-600 dark:text-green-400',
+  downloading: 'bg-sidebar-primary/15 text-sidebar-primary',
+  pending:     'bg-muted text-muted-foreground',
+  error:       'bg-destructive/15 text-destructive',
+}
+
+export function FilmStatusBadge({ status }: { status: string }) {
+  const { t } = useTranslation()
+
+  const labels: Record<string, string> = {
+    ready:       t('admin.status_ready'),
+    downloading: t('admin.status_downloading'),
+    pending:     t('admin.status_pending'),
+    error:       t('admin.status_error'),
+  }
+
+  const cls = STATUS_CLASSES[status] ?? 'bg-muted text-muted-foreground'
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
+      {labels[status] ?? status}
+    </span>
+  )
+}

--- a/frontend/src/app/(main)/admin/films/_components/FilmsTable.tsx
+++ b/frontend/src/app/(main)/admin/films/_components/FilmsTable.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { FilmRow } from './FilmRow'
+import type { AdminFilm } from '../hooks/useAdminFilms'
+
+interface FilmsTableProps {
+  films: AdminFilm[]
+  total: number
+  offset: number
+  limit: number
+  actionId: number | null
+  actionType: 'delete' | 'redownload' | null
+  onDelete: (film: AdminFilm) => void
+  onReDownload: (film: AdminFilm) => void
+  onPageChange: (offset: number) => void
+}
+
+export function FilmsTable({
+  films, total, offset, limit, actionId, actionType,
+  onDelete, onReDownload, onPageChange,
+}: FilmsTableProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-muted-foreground">
+              <th className="text-left py-2 pr-4 font-medium">{t('admin.col_title')}</th>
+              <th className="text-left py-2 pr-4 font-medium">{t('admin.col_info_hash')}</th>
+              <th className="text-left py-2 pr-4 font-medium">{t('admin.col_language')}</th>
+              <th className="text-left py-2 pr-4 font-medium">{t('admin.col_status')}</th>
+              <th className="text-right py-2 pr-4 font-medium">{t('admin.col_size')}</th>
+              <th className="text-right py-2 pr-4 font-medium">{t('admin.col_watchers')}</th>
+              <th className="text-right py-2 font-medium">{t('admin.col_actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {films.map((film) => (
+              <FilmRow
+                key={film.id}
+                film={film}
+                isActing={actionId === film.id}
+                actionType={actionId === film.id ? actionType : null}
+                onDelete={() => onDelete(film)}
+                onReDownload={() => onReDownload(film)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {total > limit && (
+        <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
+          <span>{offset + 1}–{Math.min(offset + limit, total)} / {total}</span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => onPageChange(Math.max(0, offset - limit))}
+            >
+              {t('admin.pagination_prev')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset + limit >= total}
+              onClick={() => onPageChange(offset + limit)}
+            >
+              {t('admin.pagination_next')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/app/(main)/admin/films/hooks/useAdminFilms.ts
+++ b/frontend/src/app/(main)/admin/films/hooks/useAdminFilms.ts
@@ -1,0 +1,78 @@
+'use client'
+import React from 'react'
+
+export interface AdminFilm {
+  id: number
+  movie_id: number
+  tmdb_id: number
+  info_hash: string
+  status: string
+  file_path: string
+  file_size: number
+  downloaded: number
+  progress: number
+  title: string
+  poster_path: string
+  language: string
+  created_at: string
+  watchers_count: number
+  watcher_ids: number[]
+}
+
+const LIMIT = 20
+
+export function useAdminFilms() {
+  const [films, setFilms] = React.useState<AdminFilm[]>([])
+  const [total, setTotal] = React.useState(0)
+  const [offset, setOffset] = React.useState(0)
+  const [loading, setLoading] = React.useState(true)
+  const [actionId, setActionId] = React.useState<number | null>(null)
+  const [actionType, setActionType] = React.useState<'delete' | 'redownload' | null>(null)
+
+  const fetchFilms = React.useCallback(async (off: number) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/v1/admin/films?limit=${LIMIT}&offset=${off}`, { credentials: 'include' })
+      if (!res.ok) return
+      const json = await res.json()
+      setFilms(json.data?.films ?? [])
+      setTotal(json.data?.pagination?.total ?? 0)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => { fetchFilms(0) }, [fetchFilms])
+
+  const goTo = (off: number) => {
+    setOffset(off)
+    fetchFilms(off)
+  }
+
+  const deleteFilm = async (film: AdminFilm) => {
+    setActionId(film.id)
+    setActionType('delete')
+    try {
+      await fetch(`/api/v1/admin/films/${film.id}`, { method: 'DELETE', credentials: 'include' })
+      setFilms((prev) => prev.filter((f) => f.id !== film.id))
+      setTotal((prev) => prev - 1)
+    } finally {
+      setActionId(null)
+      setActionType(null)
+    }
+  }
+
+  const reDownload = async (film: AdminFilm) => {
+    setActionId(film.id)
+    setActionType('redownload')
+    try {
+      await fetch(`/api/v1/admin/films/${film.id}/download`, { method: 'POST', credentials: 'include' })
+      await fetchFilms(offset)
+    } finally {
+      setActionId(null)
+      setActionType(null)
+    }
+  }
+
+  return { films, total, offset, loading, actionId, actionType, limit: LIMIT, goTo, deleteFilm, reDownload }
+}

--- a/frontend/src/app/(main)/admin/films/page.tsx
+++ b/frontend/src/app/(main)/admin/films/page.tsx
@@ -3,44 +3,21 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Loader2, Trash2, RefreshCw } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
+import { useAdminFilms } from './hooks/useAdminFilms'
+import { FilmsTable } from './_components/FilmsTable'
+import type { AdminFilm } from './hooks/useAdminFilms'
 
-interface AdminFilm {
-  id: number
-  movie_id: number
-  tmdb_id: number
-  info_hash: string
-  status: string
-  file_path: string
-  file_size: number
-  downloaded: number
-  progress: number
-  title: string
-  poster_path: string
-  created_at: string
-  watchers_count: number
-  watcher_ids: number[]
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '—'
-  const units = ['B', 'KB', 'MB', 'GB']
-  let v = bytes
-  let i = 0
-  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
-  return `${v.toFixed(1)} ${units[i]}`
-}
-
-interface ConfirmDialogProps {
+function ConfirmDialog({
+  title, body, cancelLabel, confirmLabel, onCancel, onConfirm,
+}: {
   title: string
   body: string
   cancelLabel: string
   confirmLabel: string
   onCancel: () => void
   onConfirm: () => void
-}
-
-function ConfirmDialog({ title, body, cancelLabel, confirmLabel, onCancel, onConfirm }: ConfirmDialogProps) {
+}) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
       <div className="bg-card border border-border rounded-xl shadow-lg p-6 max-w-sm w-full mx-4">
@@ -57,81 +34,14 @@ function ConfirmDialog({ title, body, cancelLabel, confirmLabel, onCancel, onCon
 
 export default function AdminFilmsPage() {
   const { t } = useTranslation()
-  const [films, setFilms] = React.useState<AdminFilm[]>([])
-  const [total, setTotal] = React.useState(0)
-  const [offset, setOffset] = React.useState(0)
-  const [loading, setLoading] = React.useState(true)
+  const { films, total, offset, loading, actionId, actionType, limit, goTo, deleteFilm, reDownload } = useAdminFilms()
   const [pendingDelete, setPendingDelete] = React.useState<AdminFilm | null>(null)
-  const [actionId, setActionId] = React.useState<number | null>(null)
-  const [actionType, setActionType] = React.useState<'delete' | 'redownload' | null>(null)
-  const limit = 20
-
-  const fetchFilms = React.useCallback(async (off: number) => {
-    setLoading(true)
-    try {
-      const res = await fetch(`/api/v1/admin/films?limit=${limit}&offset=${off}`, { credentials: 'include' })
-      if (!res.ok) return
-      const json = await res.json()
-      setFilms(json.data?.films ?? [])
-      setTotal(json.data?.pagination?.total ?? 0)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  React.useEffect(() => { fetchFilms(0) }, [fetchFilms])
-
-  const goTo = (off: number) => {
-    setOffset(off)
-    fetchFilms(off)
-  }
 
   const handleDeleteConfirm = async () => {
     if (!pendingDelete) return
-    const id = pendingDelete.id
+    const film = pendingDelete
     setPendingDelete(null)
-    setActionId(id)
-    setActionType('delete')
-    try {
-      await fetch(`/api/v1/admin/films/${id}`, { method: 'DELETE', credentials: 'include' })
-      setFilms((prev) => prev.filter((f) => f.id !== id))
-      setTotal((prev) => prev - 1)
-    } finally {
-      setActionId(null)
-      setActionType(null)
-    }
-  }
-
-  const handleReDownload = async (film: AdminFilm) => {
-    setActionId(film.id)
-    setActionType('redownload')
-    try {
-      await fetch(`/api/v1/admin/films/${film.id}/download`, { method: 'POST', credentials: 'include' })
-      await fetchFilms(offset)
-    } finally {
-      setActionId(null)
-      setActionType(null)
-    }
-  }
-
-  const statusLabel = (s: string) => {
-    const map: Record<string, string> = {
-      ready: t('admin.status_ready'),
-      downloading: t('admin.status_downloading'),
-      pending: t('admin.status_pending'),
-      error: t('admin.status_error'),
-    }
-    return map[s] ?? s
-  }
-
-  const statusClass = (s: string) => {
-    const map: Record<string, string> = {
-      ready: 'bg-green-500/15 text-green-600 dark:text-green-400',
-      downloading: 'bg-sidebar-primary/15 text-sidebar-primary',
-      pending: 'bg-muted text-muted-foreground',
-      error: 'bg-destructive/15 text-destructive',
-    }
-    return map[s] ?? 'bg-muted text-muted-foreground'
+    await deleteFilm(film)
   }
 
   return (
@@ -159,106 +69,17 @@ export default function AdminFilmsPage() {
           ) : films.length === 0 ? (
             <p className="text-muted-foreground text-sm py-8 text-center">{t('admin.no_films')}</p>
           ) : (
-            <>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b text-muted-foreground">
-                      <th className="text-left py-2 pr-4 font-medium">{t('admin.col_title')}</th>
-                      <th className="text-left py-2 pr-4 font-medium">{t('admin.col_status')}</th>
-                      <th className="text-right py-2 pr-4 font-medium">{t('admin.col_size')}</th>
-                      <th className="text-right py-2 pr-4 font-medium">{t('admin.col_watchers')}</th>
-                      <th className="text-right py-2 font-medium">{t('admin.col_actions')}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {films.map((film) => {
-                      const isActing = actionId === film.id
-                      return (
-                        <tr key={film.id} className="border-b last:border-0 hover:bg-muted/40 transition-colors">
-                          <td className="py-2.5 pr-4">
-                            <div className="flex items-center gap-3">
-                              {film.poster_path && (
-                                <img
-                                  src={`https://image.tmdb.org/t/p/w92${film.poster_path}`}
-                                  alt={film.title}
-                                  className="h-10 w-7 rounded object-cover shrink-0"
-                                />
-                              )}
-                              <div>
-                                <p className="font-medium leading-tight">{film.title || film.info_hash.slice(0, 12)}</p>
-                                {film.status === 'downloading' && (
-                                  <div className="mt-1 flex items-center gap-2">
-                                    <div className="h-1 w-24 rounded-full bg-muted overflow-hidden">
-                                      <div
-                                        className="h-full bg-sidebar-primary transition-all"
-                                        style={{ width: `${Math.min(100, film.progress)}%` }}
-                                      />
-                                    </div>
-                                    <span className="text-xs text-muted-foreground">{film.progress.toFixed(0)}%</span>
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          </td>
-                          <td className="py-2.5 pr-4">
-                            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusClass(film.status)}`}>
-                              {statusLabel(film.status)}
-                            </span>
-                          </td>
-                          <td className="py-2.5 pr-4 text-right tabular-nums text-muted-foreground">
-                            {formatBytes(film.file_size)}
-                          </td>
-                          <td className="py-2.5 pr-4 text-right tabular-nums">{film.watchers_count}</td>
-                          <td className="py-2.5 text-right">
-                            <div className="flex items-center justify-end gap-2">
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                disabled={isActing}
-                                onClick={() => handleReDownload(film)}
-                                title={t('admin.action_redownload')}
-                              >
-                                {isActing && actionType === 'redownload'
-                                  ? <Loader2 className="size-3.5 animate-spin" />
-                                  : <RefreshCw className="size-3.5" />
-                                }
-                              </Button>
-                              <Button
-                                variant="destructive"
-                                size="sm"
-                                disabled={isActing}
-                                onClick={() => setPendingDelete(film)}
-                                title={t('admin.action_delete')}
-                              >
-                                {isActing && actionType === 'delete'
-                                  ? <Loader2 className="size-3.5 animate-spin" />
-                                  : <Trash2 className="size-3.5" />
-                                }
-                              </Button>
-                            </div>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-
-              {total > limit && (
-                <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
-                  <span>{offset + 1}–{Math.min(offset + limit, total)} / {total}</span>
-                  <div className="flex gap-2">
-                    <Button variant="outline" size="sm" disabled={offset === 0} onClick={() => goTo(Math.max(0, offset - limit))}>
-                      {t('admin.pagination_prev')}
-                    </Button>
-                    <Button variant="outline" size="sm" disabled={offset + limit >= total} onClick={() => goTo(offset + limit)}>
-                      {t('admin.pagination_next')}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </>
+            <FilmsTable
+              films={films}
+              total={total}
+              offset={offset}
+              limit={limit}
+              actionId={actionId}
+              actionType={actionType}
+              onDelete={setPendingDelete}
+              onReDownload={reDownload}
+              onPageChange={goTo}
+            />
           )}
         </CardContent>
       </Card>

--- a/frontend/src/app/(main)/admin/films/page.tsx
+++ b/frontend/src/app/(main)/admin/films/page.tsx
@@ -1,0 +1,267 @@
+'use client'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Loader2, Trash2, RefreshCw } from 'lucide-react'
+
+interface AdminFilm {
+  id: number
+  movie_id: number
+  tmdb_id: number
+  info_hash: string
+  status: string
+  file_path: string
+  file_size: number
+  downloaded: number
+  progress: number
+  title: string
+  poster_path: string
+  created_at: string
+  watchers_count: number
+  watcher_ids: number[]
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '—'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let v = bytes
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(1)} ${units[i]}`
+}
+
+interface ConfirmDialogProps {
+  title: string
+  body: string
+  cancelLabel: string
+  confirmLabel: string
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+function ConfirmDialog({ title, body, cancelLabel, confirmLabel, onCancel, onConfirm }: ConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="bg-card border border-border rounded-xl shadow-lg p-6 max-w-sm w-full mx-4">
+        <h2 className="text-base font-semibold mb-2">{title}</h2>
+        <p className="text-sm text-muted-foreground mb-6">{body}</p>
+        <div className="flex gap-3 justify-end">
+          <Button variant="outline" size="sm" onClick={onCancel}>{cancelLabel}</Button>
+          <Button variant="destructive" size="sm" onClick={onConfirm}>{confirmLabel}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminFilmsPage() {
+  const { t } = useTranslation()
+  const [films, setFilms] = React.useState<AdminFilm[]>([])
+  const [total, setTotal] = React.useState(0)
+  const [offset, setOffset] = React.useState(0)
+  const [loading, setLoading] = React.useState(true)
+  const [pendingDelete, setPendingDelete] = React.useState<AdminFilm | null>(null)
+  const [actionId, setActionId] = React.useState<number | null>(null)
+  const [actionType, setActionType] = React.useState<'delete' | 'redownload' | null>(null)
+  const limit = 20
+
+  const fetchFilms = React.useCallback(async (off: number) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/v1/admin/films?limit=${limit}&offset=${off}`, { credentials: 'include' })
+      if (!res.ok) return
+      const json = await res.json()
+      setFilms(json.data?.films ?? [])
+      setTotal(json.data?.pagination?.total ?? 0)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => { fetchFilms(0) }, [fetchFilms])
+
+  const goTo = (off: number) => {
+    setOffset(off)
+    fetchFilms(off)
+  }
+
+  const handleDeleteConfirm = async () => {
+    if (!pendingDelete) return
+    const id = pendingDelete.id
+    setPendingDelete(null)
+    setActionId(id)
+    setActionType('delete')
+    try {
+      await fetch(`/api/v1/admin/films/${id}`, { method: 'DELETE', credentials: 'include' })
+      setFilms((prev) => prev.filter((f) => f.id !== id))
+      setTotal((prev) => prev - 1)
+    } finally {
+      setActionId(null)
+      setActionType(null)
+    }
+  }
+
+  const handleReDownload = async (film: AdminFilm) => {
+    setActionId(film.id)
+    setActionType('redownload')
+    try {
+      await fetch(`/api/v1/admin/films/${film.id}/download`, { method: 'POST', credentials: 'include' })
+      await fetchFilms(offset)
+    } finally {
+      setActionId(null)
+      setActionType(null)
+    }
+  }
+
+  const statusLabel = (s: string) => {
+    const map: Record<string, string> = {
+      ready: t('admin.status_ready'),
+      downloading: t('admin.status_downloading'),
+      pending: t('admin.status_pending'),
+      error: t('admin.status_error'),
+    }
+    return map[s] ?? s
+  }
+
+  const statusClass = (s: string) => {
+    const map: Record<string, string> = {
+      ready: 'bg-green-500/15 text-green-600 dark:text-green-400',
+      downloading: 'bg-sidebar-primary/15 text-sidebar-primary',
+      pending: 'bg-muted text-muted-foreground',
+      error: 'bg-destructive/15 text-destructive',
+    }
+    return map[s] ?? 'bg-muted text-muted-foreground'
+  }
+
+  return (
+    <>
+      {pendingDelete && (
+        <ConfirmDialog
+          title={t('admin.confirm_delete_title')}
+          body={t('admin.confirm_delete_body')}
+          cancelLabel={t('admin.confirm_delete_cancel')}
+          confirmLabel={t('admin.confirm_delete_confirm')}
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={handleDeleteConfirm}
+        />
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('admin.films_title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : films.length === 0 ? (
+            <p className="text-muted-foreground text-sm py-8 text-center">{t('admin.no_films')}</p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-muted-foreground">
+                      <th className="text-left py-2 pr-4 font-medium">{t('admin.col_title')}</th>
+                      <th className="text-left py-2 pr-4 font-medium">{t('admin.col_status')}</th>
+                      <th className="text-right py-2 pr-4 font-medium">{t('admin.col_size')}</th>
+                      <th className="text-right py-2 pr-4 font-medium">{t('admin.col_watchers')}</th>
+                      <th className="text-right py-2 font-medium">{t('admin.col_actions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {films.map((film) => {
+                      const isActing = actionId === film.id
+                      return (
+                        <tr key={film.id} className="border-b last:border-0 hover:bg-muted/40 transition-colors">
+                          <td className="py-2.5 pr-4">
+                            <div className="flex items-center gap-3">
+                              {film.poster_path && (
+                                <img
+                                  src={`https://image.tmdb.org/t/p/w92${film.poster_path}`}
+                                  alt={film.title}
+                                  className="h-10 w-7 rounded object-cover shrink-0"
+                                />
+                              )}
+                              <div>
+                                <p className="font-medium leading-tight">{film.title || film.info_hash.slice(0, 12)}</p>
+                                {film.status === 'downloading' && (
+                                  <div className="mt-1 flex items-center gap-2">
+                                    <div className="h-1 w-24 rounded-full bg-muted overflow-hidden">
+                                      <div
+                                        className="h-full bg-sidebar-primary transition-all"
+                                        style={{ width: `${Math.min(100, film.progress)}%` }}
+                                      />
+                                    </div>
+                                    <span className="text-xs text-muted-foreground">{film.progress.toFixed(0)}%</span>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </td>
+                          <td className="py-2.5 pr-4">
+                            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusClass(film.status)}`}>
+                              {statusLabel(film.status)}
+                            </span>
+                          </td>
+                          <td className="py-2.5 pr-4 text-right tabular-nums text-muted-foreground">
+                            {formatBytes(film.file_size)}
+                          </td>
+                          <td className="py-2.5 pr-4 text-right tabular-nums">{film.watchers_count}</td>
+                          <td className="py-2.5 text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => handleReDownload(film)}
+                                title={t('admin.action_redownload')}
+                              >
+                                {isActing && actionType === 'redownload'
+                                  ? <Loader2 className="size-3.5 animate-spin" />
+                                  : <RefreshCw className="size-3.5" />
+                                }
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => setPendingDelete(film)}
+                                title={t('admin.action_delete')}
+                              >
+                                {isActing && actionType === 'delete'
+                                  ? <Loader2 className="size-3.5 animate-spin" />
+                                  : <Trash2 className="size-3.5" />
+                                }
+                              </Button>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              {total > limit && (
+                <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
+                  <span>{offset + 1}–{Math.min(offset + limit, total)} / {total}</span>
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" disabled={offset === 0} onClick={() => goTo(Math.max(0, offset - limit))}>
+                      {t('admin.pagination_prev')}
+                    </Button>
+                    <Button variant="outline" size="sm" disabled={offset + limit >= total} onClick={() => goTo(offset + limit)}>
+                      {t('admin.pagination_next')}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/frontend/src/app/(main)/admin/layout.tsx
+++ b/frontend/src/app/(main)/admin/layout.tsx
@@ -34,6 +34,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   }
 
   const tabs = [
+    { href: '/admin/overview', label: t('admin.tab_overview') },
     { href: '/admin/users', label: t('admin.tab_users') },
     { href: '/admin/films', label: t('admin.tab_films') },
   ]

--- a/frontend/src/app/(main)/admin/layout.tsx
+++ b/frontend/src/app/(main)/admin/layout.tsx
@@ -1,0 +1,66 @@
+'use client'
+import React from 'react'
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
+import { Loader2 } from 'lucide-react'
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation()
+  const pathname = usePathname()
+  const router = useRouter()
+  const [ready, setReady] = React.useState(false)
+
+  React.useEffect(() => {
+    fetch('/api/v1/users/profile', { credentials: 'include' })
+      .then((r) => r.json())
+      .then(({ data }) => {
+        if (data?.profile?.role !== 'admin') {
+          router.replace('/')
+        } else {
+          setReady(true)
+        }
+      })
+      .catch(() => router.replace('/'))
+  }, [router])
+
+  if (!ready) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  const tabs = [
+    { href: '/admin/users', label: t('admin.tab_users') },
+    { href: '/admin/films', label: t('admin.tab_films') },
+  ]
+
+  return (
+    <div className="container mx-auto p-6 max-w-6xl">
+      <h1 className="text-3xl font-bold mb-6">{t('admin.title')}</h1>
+      <nav className="flex gap-1 mb-6 border-b">
+        {tabs.map((tab) => {
+          const active = pathname.startsWith(tab.href)
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={cn(
+                'px-4 py-2 text-sm font-medium rounded-t-md transition-colors -mb-px border-b-2',
+                active
+                  ? 'border-sidebar-primary text-sidebar-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border',
+              )}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/admin/overview/page.tsx
+++ b/frontend/src/app/(main)/admin/overview/page.tsx
@@ -1,0 +1,216 @@
+'use client'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Loader2, Users, Film, Eye, TrendingUp } from 'lucide-react'
+import {
+  AreaChart, Area,
+  BarChart, Bar,
+  PieChart, Pie, Cell,
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
+} from 'recharts'
+
+interface AdminStats {
+  total_users: number
+  total_films: number
+  total_watches: number
+  films_by_status: { status: string; count: number }[]
+  watches_per_day: { day: string; count: number }[]
+  top_films: { title: string; watches: number }[]
+  registrations_per_month: { month: string; count: number }[]
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  ready:       'oklch(0.627 0.194 149.214)',
+  downloading: 'oklch(0.488 0.243 264.376)',
+  pending:     'oklch(0.6 0.05 264)',
+  error:       'oklch(0.577 0.245 27.325)',
+}
+
+function StatCard({ icon: Icon, label, value }: { icon: React.ElementType; label: string; value: number }) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-4 pt-6">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary/10">
+          <Icon className="size-6 text-sidebar-primary" />
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">{label}</p>
+          <p className="text-2xl font-bold tabular-nums">{value.toLocaleString()}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function AdminOverviewPage() {
+  const { t } = useTranslation()
+  const [stats, setStats] = React.useState<AdminStats | null>(null)
+  const [loading, setLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    fetch('/api/v1/admin/stats', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((json) => setStats(json.data ?? null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-24">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!stats) {
+    return <p className="text-muted-foreground text-sm py-8 text-center">{t('admin.stats_error')}</p>
+  }
+
+  const readyCount = stats.films_by_status.find((s) => s.status === 'ready')?.count ?? 0
+
+  return (
+    <div className="space-y-6">
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard icon={Users}     label={t('admin.stat_users')}    value={stats.total_users} />
+        <StatCard icon={Film}      label={t('admin.stat_films')}    value={stats.total_films} />
+        <StatCard icon={TrendingUp} label={t('admin.stat_ready')}   value={readyCount} />
+        <StatCard icon={Eye}       label={t('admin.stat_watches')}  value={stats.total_watches} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Activity — area chart */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">{t('admin.chart_activity')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart data={stats.watches_per_day} margin={{ top: 4, right: 8, left: -24, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="watchGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%"  stopColor="oklch(0.488 0.243 264.376)" stopOpacity={0.25} />
+                    <stop offset="95%" stopColor="oklch(0.488 0.243 264.376)" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis
+                  dataKey="day"
+                  tick={{ fontSize: 11 }}
+                  tickFormatter={(v: string) => v.slice(5)}
+                  className="text-muted-foreground"
+                />
+                <YAxis tick={{ fontSize: 11 }} allowDecimals={false} className="text-muted-foreground" />
+                <Tooltip
+                  contentStyle={{ fontSize: 12 }}
+                  labelFormatter={(v: string) => v}
+                  formatter={(v: number) => [v, t('admin.stat_watches')]}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="count"
+                  stroke="oklch(0.488 0.243 264.376)"
+                  strokeWidth={2}
+                  fill="url(#watchGrad)"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* Films by status — pie chart */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t('admin.chart_status')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart>
+                <Pie
+                  data={stats.films_by_status}
+                  dataKey="count"
+                  nameKey="status"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={55}
+                  outerRadius={80}
+                  paddingAngle={3}
+                >
+                  {stats.films_by_status.map((entry) => (
+                    <Cell
+                      key={entry.status}
+                      fill={STATUS_COLORS[entry.status] ?? 'oklch(0.6 0.05 264)'}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{ fontSize: 12 }}
+                  formatter={(v: number, name: string) => [v, t(`admin.status_${name}`) || name]}
+                />
+                <Legend
+                  iconType="circle"
+                  iconSize={8}
+                  formatter={(value: string) => t(`admin.status_${value}`) || value}
+                  wrapperStyle={{ fontSize: 12 }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Top films — horizontal bar */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t('admin.chart_top_films')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart
+                data={stats.top_films}
+                layout="vertical"
+                margin={{ top: 4, right: 16, left: 8, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" horizontal={false} className="stroke-border" />
+                <XAxis type="number" tick={{ fontSize: 11 }} allowDecimals={false} className="text-muted-foreground" />
+                <YAxis
+                  type="category"
+                  dataKey="title"
+                  width={120}
+                  tick={{ fontSize: 11 }}
+                  tickFormatter={(v: string) => v.length > 16 ? v.slice(0, 15) + '…' : v}
+                  className="text-muted-foreground"
+                />
+                <Tooltip contentStyle={{ fontSize: 12 }} formatter={(v: number) => [v, t('admin.stat_watches')]} />
+                <Bar dataKey="watches" fill="oklch(0.488 0.243 264.376)" radius={[0, 4, 4, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* Registrations per month — bar chart */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t('admin.chart_registrations')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart
+                data={stats.registrations_per_month}
+                margin={{ top: 4, right: 8, left: -24, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="month" tick={{ fontSize: 11 }} className="text-muted-foreground" />
+                <YAxis tick={{ fontSize: 11 }} allowDecimals={false} className="text-muted-foreground" />
+                <Tooltip contentStyle={{ fontSize: 12 }} formatter={(v: number) => [v, t('admin.stat_users')]} />
+                <Bar dataKey="count" fill="oklch(0.577 0.245 27.325)" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/admin/page.tsx
+++ b/frontend/src/app/(main)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AdminPage() {
+  redirect('/admin/users')
+}

--- a/frontend/src/app/(main)/admin/page.tsx
+++ b/frontend/src/app/(main)/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export default function AdminPage() {
-  redirect('/admin/users')
+  redirect('/admin/overview')
 }

--- a/frontend/src/app/(main)/admin/users/page.tsx
+++ b/frontend/src/app/(main)/admin/users/page.tsx
@@ -1,0 +1,134 @@
+'use client'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Loader2 } from 'lucide-react'
+
+interface AdminUser {
+  id: number
+  username: string
+  email: string
+  first_name: string
+  last_name: string
+  avatar_url: string
+  role: string
+  email_verified: boolean
+  created_at: string
+  films_watched: number
+  films_downloaded: number
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+export default function AdminUsersPage() {
+  const { t } = useTranslation()
+  const [users, setUsers] = React.useState<AdminUser[]>([])
+  const [total, setTotal] = React.useState(0)
+  const [offset, setOffset] = React.useState(0)
+  const [loading, setLoading] = React.useState(true)
+  const limit = 20
+
+  const fetchUsers = React.useCallback(async (off: number) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/v1/admin/users?limit=${limit}&offset=${off}`, { credentials: 'include' })
+      if (!res.ok) return
+      const json = await res.json()
+      setUsers(json.data?.users ?? [])
+      setTotal(json.data?.pagination?.total ?? 0)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => { fetchUsers(0) }, [fetchUsers])
+
+  const goTo = (off: number) => {
+    setOffset(off)
+    fetchUsers(off)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('admin.users_title')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : users.length === 0 ? (
+          <p className="text-muted-foreground text-sm py-8 text-center">{t('admin.no_users')}</p>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-muted-foreground">
+                    <th className="text-left py-2 pr-4 font-medium">{t('admin.col_username')}</th>
+                    <th className="text-left py-2 pr-4 font-medium">{t('admin.col_email')}</th>
+                    <th className="text-left py-2 pr-4 font-medium">{t('admin.col_role')}</th>
+                    <th className="text-left py-2 pr-4 font-medium">{t('admin.col_registered')}</th>
+                    <th className="text-right py-2 pr-4 font-medium">{t('admin.col_watched')}</th>
+                    <th className="text-right py-2 font-medium">{t('admin.col_downloaded')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map((u) => (
+                    <tr key={u.id} className="border-b last:border-0 hover:bg-muted/40 transition-colors">
+                      <td className="py-2.5 pr-4">
+                        <div className="flex items-center gap-2">
+                          <img
+                            src={u.avatar_url || `https://robohash.org/${u.id}.png?set=set1`}
+                            alt={u.username}
+                            className="size-7 rounded-full object-cover shrink-0"
+                          />
+                          <span className="font-medium">{u.username}</span>
+                        </div>
+                      </td>
+                      <td className="py-2.5 pr-4 text-muted-foreground">{u.email}</td>
+                      <td className="py-2.5 pr-4">
+                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                          u.role === 'admin'
+                            ? 'bg-sidebar-primary/15 text-sidebar-primary'
+                            : 'bg-muted text-muted-foreground'
+                        }`}>
+                          {u.role}
+                        </span>
+                      </td>
+                      <td className="py-2.5 pr-4 text-muted-foreground">{formatDate(u.created_at)}</td>
+                      <td className="py-2.5 pr-4 text-right tabular-nums">{u.films_watched}</td>
+                      <td className="py-2.5 text-right tabular-nums">{u.films_downloaded}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {total > limit && (
+              <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
+                <span>{offset + 1}–{Math.min(offset + limit, total)} / {total}</span>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" disabled={offset === 0} onClick={() => goTo(Math.max(0, offset - limit))}>
+                    {t('admin.pagination_prev')}
+                  </Button>
+                  <Button variant="outline" size="sm" disabled={offset + limit >= total} onClick={() => goTo(offset + limit)}>
+                    {t('admin.pagination_next')}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -16,6 +16,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   const isProfilePage = pathname.includes('/profile')
   const [avatarUrl, setAvatarUrl] = React.useState('')
   const [initials, setInitials] = React.useState('HT')
+  const [isAdmin, setIsAdmin] = React.useState(false)
 
   React.useEffect(() => {
     fetch('/api/v1/users/profile', { credentials: 'include' })
@@ -26,6 +27,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
         setAvatarUrl(p.avatar_url || `https://robohash.org/${p.id}.png?set=set1`)
         const i = ((p.first_name?.[0] ?? '') + (p.last_name?.[0] ?? '')).toUpperCase() || p.username?.[0]?.toUpperCase() || 'HT'
         setInitials(i)
+        setIsAdmin(p.role === 'admin')
       })
       .catch(() => {})
   }, [])
@@ -49,6 +51,11 @@ export default function MainLayout({ children }: { children: ReactNode }) {
           )}
           <span className="font-bold text-lg tracking-tight flex-1 text-center">Hypertube</span>
           <div className="flex items-center gap-3">
+            {isAdmin && (
+              <Link href="/admin">
+                <Button variant="outline" size="sm">{t('nav.admin')}</Button>
+              </Link>
+            )}
             <LanguageSwitcher />
             <LogoutButton />
           </div>

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -49,15 +49,16 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
     let cancelled = false
     setState('checking')
+    const hash = selected.hash.toLowerCase()
     void (async () => {
       try {
-        const res = await fetch(`/api/v1/torrent/status/${selected.hash}`, { credentials: 'include' })
+        const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
         if (cancelled) return
         if (res.ok) {
           const json = await res.json()
           const { status } = (json.data ?? json) as { status: string }
           if (!cancelled && status === 'ready') {
-            setInfoHash(selected.hash)
+            setInfoHash(hash)
             setState('streaming')
             return
           }
@@ -112,7 +113,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
       })
       if (!res.ok) throw new Error(`${res.status}`)
       const json = await res.json()
-      const hash = json.data?.info_hash ?? json.info_hash
+      const hash = (json.data?.info_hash ?? json.info_hash as string).toLowerCase()
       setInfoHash(hash)
       setState('downloading')
       pollStatus(hash)

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -58,7 +58,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
 
         setProgress(Math.round((prog ?? 0) * 100))
 
-        if (status === 'downloading' || status === 'completed') {
+        if (status === 'downloading' || status === 'ready') {
           stopPolling()
           setState('streaming')
         }

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -22,6 +22,8 @@ interface MoviePlayerProps {
   movieId: number
 }
 
+const SAVE_INTERVAL_MS = 5000
+
 export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Torrent | null>(torrents[0] ?? null)
@@ -30,6 +32,7 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const [infoHash, setInfoHash] = useState<string | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const saveRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
 
   const stopPolling = useCallback(() => {
@@ -39,9 +42,51 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
   }, [])
 
-  useEffect(() => () => stopPolling(), [stopPolling])
+  const stopSaving = useCallback(() => {
+    if (saveRef.current) {
+      clearInterval(saveRef.current)
+      saveRef.current = null
+    }
+  }, [])
 
-  // On mount and when the selected torrent changes, check if it is already ready on the server.
+  useEffect(() => () => { stopPolling(); stopSaving() }, [stopPolling, stopSaving])
+
+  // Restore saved position once the video element is ready.
+  const restorePosition = useCallback(async () => {
+    const video = videoRef.current
+    if (!video) return
+    try {
+      const res = await fetch(`/api/v1/movies/${movieId}/progress`, { credentials: 'include' })
+      if (!res.ok) return
+      const json = await res.json()
+      const sec: number = (json.data ?? json).progress_sec ?? 0
+      if (sec > 0) video.currentTime = sec
+    } catch {
+      // ignore — just start from the beginning
+    }
+  }, [movieId])
+
+  // Periodically save the current playback position.
+  const startSaving = useCallback(() => {
+    saveRef.current = setInterval(async () => {
+      const video = videoRef.current
+      if (!video || video.paused || video.ended) return
+      const sec = Math.floor(video.currentTime)
+      if (sec <= 0) return
+      try {
+        await fetch(`/api/v1/movies/${movieId}/progress`, {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ progress_sec: sec }),
+        })
+      } catch {
+        // ignore transient save errors
+      }
+    }, SAVE_INTERVAL_MS)
+  }, [movieId])
+
+  // Check if the selected torrent is already ready on the server.
   useEffect(() => {
     if (!selected) {
       setState('idle')
@@ -49,9 +94,9 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
     }
     let cancelled = false
     setState('checking')
-    const hash = selected.hash.toLowerCase()
     void (async () => {
       try {
+        const hash = selected.hash.toLowerCase()
         const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
         if (cancelled) return
         if (res.ok) {
@@ -64,13 +109,25 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
           }
         }
       } catch {
-        // status check failed — fall through to idle
+        // fall through to idle
       }
       if (!cancelled) setState('idle')
     })()
     return () => { cancelled = true }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected])
+
+  // When streaming starts, restore position and begin saving.
+  useEffect(() => {
+    if (state !== 'streaming') return
+    stopSaving()
+    // Delay slightly so the video element has time to mount.
+    const t = setTimeout(() => {
+      void restorePosition()
+      startSaving()
+    }, 300)
+    return () => clearTimeout(t)
+  }, [state, restorePosition, startSaving, stopSaving])
 
   const pollStatus = useCallback((hash: string) => {
     pollRef.current = setInterval(async () => {

--- a/frontend/src/components/page/MoviePlayer.tsx
+++ b/frontend/src/components/page/MoviePlayer.tsx
@@ -15,7 +15,7 @@ interface Torrent {
   magnet: string
 }
 
-type PlayerState = 'idle' | 'starting' | 'downloading' | 'streaming' | 'error'
+type PlayerState = 'idle' | 'checking' | 'starting' | 'downloading' | 'streaming' | 'error'
 
 interface MoviePlayerProps {
   torrents: Torrent[]
@@ -25,7 +25,7 @@ interface MoviePlayerProps {
 export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Torrent | null>(torrents[0] ?? null)
-  const [state, setState] = useState<PlayerState>('idle')
+  const [state, setState] = useState<PlayerState>('checking')
   const [progress, setProgress] = useState(0)
   const [infoHash, setInfoHash] = useState<string | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
@@ -40,6 +40,36 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
   }, [])
 
   useEffect(() => () => stopPolling(), [stopPolling])
+
+  // On mount and when the selected torrent changes, check if it is already ready on the server.
+  useEffect(() => {
+    if (!selected) {
+      setState('idle')
+      return
+    }
+    let cancelled = false
+    setState('checking')
+    void (async () => {
+      try {
+        const res = await fetch(`/api/v1/torrent/status/${selected.hash}`, { credentials: 'include' })
+        if (cancelled) return
+        if (res.ok) {
+          const json = await res.json()
+          const { status } = (json.data ?? json) as { status: string }
+          if (!cancelled && status === 'ready') {
+            setInfoHash(selected.hash)
+            setState('streaming')
+            return
+          }
+        }
+      } catch {
+        // status check failed — fall through to idle
+      }
+      if (!cancelled) setState('idle')
+    })()
+    return () => { cancelled = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected])
 
   const pollStatus = useCallback((hash: string) => {
     pollRef.current = setInterval(async () => {
@@ -113,11 +143,11 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
         </video>
       ) : (
         <div className="w-full aspect-video rounded-lg bg-muted flex items-center justify-center">
+          {(state === 'checking' || state === 'starting') && (
+            <span className="text-muted-foreground text-sm animate-pulse">{t('movie.loading')}</span>
+          )}
           {state === 'idle' && (
             <span className="text-muted-foreground text-sm">{t('movie.select_quality')}</span>
-          )}
-          {state === 'starting' && (
-            <span className="text-muted-foreground text-sm animate-pulse">{t('movie.loading')}</span>
           )}
           {state === 'downloading' && (
             <div className="flex flex-col items-center gap-3 w-48">
@@ -143,14 +173,14 @@ export function MoviePlayer({ torrents, movieId }: MoviePlayerProps) {
           {torrents.map(torrent => (
             <button
               key={torrent.hash}
-              onClick={() => { if (state === 'idle') setSelected(torrent) }}
-              disabled={state !== 'idle'}
+              onClick={() => { if (state === 'idle' || state === 'checking') setSelected(torrent) }}
+              disabled={state !== 'idle' && state !== 'checking'}
               className={cn(
                 'text-xs px-3 py-1.5 rounded-md border transition-colors',
                 selected?.hash === torrent.hash
                   ? 'bg-sidebar-primary text-white border-sidebar-primary'
                   : 'bg-muted border-border text-muted-foreground hover:border-sidebar-primary',
-                state !== 'idle' && 'opacity-50 cursor-not-allowed',
+                state !== 'idle' && state !== 'checking' && 'opacity-50 cursor-not-allowed',
               )}
             >
               {torrent.quality} {torrent.type && `· ${torrent.type}`}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2,7 +2,51 @@
   "app_tagline": "Watch your movies in streaming",
 
   "nav": {
-    "home": "Home"
+    "home": "Home",
+    "admin": "Admin"
+  },
+
+  "admin": {
+    "title": "Administration panel",
+    "tab_users": "Users",
+    "tab_films": "Films",
+    "access_denied": "Access denied.",
+    "loading": "Loading…",
+
+    "users_title": "User management",
+    "col_username": "Username",
+    "col_email": "Email",
+    "col_role": "Role",
+    "col_registered": "Registered",
+    "col_watched": "Films watched",
+    "col_downloaded": "Films downloaded",
+    "no_users": "No users found.",
+
+    "films_title": "Downloaded films",
+    "col_title": "Title",
+    "col_status": "Status",
+    "col_size": "Size",
+    "col_progress": "Progress",
+    "col_watchers": "Watchers",
+    "col_actions": "Actions",
+    "no_films": "No downloaded films.",
+    "action_delete": "Delete",
+    "action_redownload": "Re-download",
+    "action_deleting": "Deleting…",
+    "action_redownloading": "Starting…",
+
+    "confirm_delete_title": "Delete this film?",
+    "confirm_delete_body": "The file will be removed from disk and the watch history cleared. This action is irreversible.",
+    "confirm_delete_cancel": "Cancel",
+    "confirm_delete_confirm": "Delete",
+
+    "status_ready": "Ready",
+    "status_downloading": "Downloading",
+    "status_pending": "Pending",
+    "status_error": "Error",
+
+    "pagination_prev": "Previous",
+    "pagination_next": "Next"
   },
 
   "profile": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,8 +8,21 @@
 
   "admin": {
     "title": "Administration panel",
+    "tab_overview": "Overview",
     "tab_users": "Users",
     "tab_films": "Films",
+
+    "stat_users": "Users",
+    "stat_films": "Downloaded films",
+    "stat_ready": "Ready to watch",
+    "stat_watches": "Watch events",
+
+    "chart_activity": "Activity (last 30 days)",
+    "chart_status": "Films by status",
+    "chart_top_films": "Most watched films",
+    "chart_registrations": "Registrations (last 6 months)",
+
+    "stats_error": "Could not load statistics.",
     "access_denied": "Access denied.",
     "loading": "Loading…",
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -24,6 +24,8 @@
 
     "films_title": "Downloaded films",
     "col_title": "Title",
+    "col_info_hash": "Torrent key",
+    "col_language": "Language",
     "col_status": "Status",
     "col_size": "Size",
     "col_progress": "Progress",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -2,7 +2,51 @@
   "app_tagline": "Regardez vos films en streaming",
 
   "nav": {
-    "home": "Accueil"
+    "home": "Accueil",
+    "admin": "Admin"
+  },
+
+  "admin": {
+    "title": "Panneau d'administration",
+    "tab_users": "Utilisateurs",
+    "tab_films": "Films",
+    "access_denied": "Accès refusé.",
+    "loading": "Chargement…",
+
+    "users_title": "Gestion des utilisateurs",
+    "col_username": "Nom d'utilisateur",
+    "col_email": "Email",
+    "col_role": "Rôle",
+    "col_registered": "Inscription",
+    "col_watched": "Films vus",
+    "col_downloaded": "Films téléchargés",
+    "no_users": "Aucun utilisateur trouvé.",
+
+    "films_title": "Films téléchargés",
+    "col_title": "Titre",
+    "col_status": "Statut",
+    "col_size": "Taille",
+    "col_progress": "Progression",
+    "col_watchers": "Spectateurs",
+    "col_actions": "Actions",
+    "no_films": "Aucun film téléchargé.",
+    "action_delete": "Supprimer",
+    "action_redownload": "Re-télécharger",
+    "action_deleting": "Suppression…",
+    "action_redownloading": "Lancement…",
+
+    "confirm_delete_title": "Supprimer ce film ?",
+    "confirm_delete_body": "Le fichier sera supprimé du disque et l'historique de visionnage effacé. Cette action est irréversible.",
+    "confirm_delete_cancel": "Annuler",
+    "confirm_delete_confirm": "Supprimer",
+
+    "status_ready": "Prêt",
+    "status_downloading": "Téléchargement",
+    "status_pending": "En attente",
+    "status_error": "Erreur",
+
+    "pagination_prev": "Précédent",
+    "pagination_next": "Suivant"
   },
 
   "profile": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -24,6 +24,8 @@
 
     "films_title": "Films téléchargés",
     "col_title": "Titre",
+    "col_info_hash": "Clé torrent",
+    "col_language": "Langue",
     "col_status": "Statut",
     "col_size": "Taille",
     "col_progress": "Progression",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -8,8 +8,21 @@
 
   "admin": {
     "title": "Panneau d'administration",
+    "tab_overview": "Vue générale",
     "tab_users": "Utilisateurs",
     "tab_films": "Films",
+
+    "stat_users": "Utilisateurs",
+    "stat_films": "Films téléchargés",
+    "stat_ready": "Prêts à lire",
+    "stat_watches": "Visionnages",
+
+    "chart_activity": "Activité (30 derniers jours)",
+    "chart_status": "Films par statut",
+    "chart_top_films": "Films les plus regardés",
+    "chart_registrations": "Inscriptions (6 derniers mois)",
+
+    "stats_error": "Impossible de charger les statistiques.",
     "access_denied": "Accès refusé.",
     "loading": "Chargement…",
 

--- a/services/database/02_enums.sql
+++ b/services/database/02_enums.sql
@@ -2,6 +2,11 @@
 -- ENUMS
 -- ====================
 
+CREATE TYPE user_role_enum AS ENUM (
+    'user',
+    'admin'
+);
+
 CREATE TYPE torrent_status_enum AS ENUM (
     'pending',
     'downloading',

--- a/services/database/03_user_tables.sql
+++ b/services/database/03_user_tables.sql
@@ -11,6 +11,7 @@ CREATE TABLE users (
     last_name   VARCHAR(100),
     avatar_url  TEXT,
     language    VARCHAR(10)  DEFAULT 'fr',
+    role        user_role_enum DEFAULT 'user',
     email_verified BOOLEAN   DEFAULT FALSE,
     created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
     updated_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary

- Add admin overview page with KPI cards and 4 charts (activity area chart, films-by-status donut, top films bar chart, registrations bar chart) using Recharts
- Add `GET /api/v1/admin/stats` endpoint (torrent-service) with aggregated stats across users, torrents, movies and watch_history tables
- Add films management page with torrent key (`info_hash`), language, and clickable title linking to the movie page
- Refactor films page into `useAdminFilms` hook + `FilmRow`, `FilmsTable`, `FilmStatusBadge` components
- Fix `LogoutButton` — replace `<form action={logout}>` with `useTransition` call (Server Action signature mismatch)
- Fix SQL `GROUP BY` alias errors for PostgreSQL in stats queries
- Add `language` field to `AdminFilmRow` pulled from the `movies` table

## Test plan

- [ ] Navigate to `/admin` → redirects to `/admin/overview`
- [ ] Overview page loads all 4 stat cards and 4 charts without errors
- [ ] Films page shows torrent key and language columns; title is a clickable link to the movie
- [ ] Delete and re-download actions still work on the films page
- [ ] Logout button works without console errors
- [ ] `GET /api/v1/admin/stats` returns 200 (no more 500 from GROUP BY alias)