### PR TITLE
fix(build): remove unused log import and fix undefined searchResult

### DIFF
--- a/api/library-service/src/handlers/movies.go
+++ b/api/library-service/src/handlers/movies.go
@@ -72,18 +72,10 @@ func (h *MovieHandler) Movies(c *gin.Context) {
 		return
 	}
 
-	result = models.CursorResult{
-		Results: searchResult.Results,
-		Total:   searchResult.TotalCount,
-	}
-	if page < searchResult.TotalPages {
-		// When year is filtered, List() scans 10 YTS pages at once, so the
-		// next cursor must skip 10 pages forward instead of just 1.
-		nextPage := page + 1
-		if year > 0 {
-			nextPage = page + 10
-		}
-		result.NextCursor = encodeCursor(nextPage)
+	result, err := h.fetchMovies(params, year)
+	if err != nil {
+		utils.RespondError(c, http.StatusBadGateway, "failed to fetch movies")
+		return
 	}
 
 	cacheSet(cacheKey, result, ytsCacheTTL)

--- a/api/torrent-service/src/handlers/subtitle.go
+++ b/api/torrent-service/src/handlers/subtitle.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
## Summary
- Remove unused `"log"` import in `torrent-service/src/handlers/subtitle.go`
- Fix `undefined: searchResult` in `library-service/src/handlers/movies.go` by replacing the stale inline block with the existing `h.fetchMovies()` call