### PR TITLE
feat(subtitles): list available languages + fix torrent extraction

### DIFF
--- a/api/torrent-service/src/handlers/subtitle.go
+++ b/api/torrent-service/src/handlers/subtitle.go
@@ -15,7 +15,8 @@ import (
 )
 
 // SubtitleAvailableHandler handles GET /api/v1/movies/:id/subtitles
-// Returns the list of language codes that are already cached on disk for this movie.
+// Returns the list of language codes that are either cached on disk or available
+// for download from OpenSubtitles for this movie.
 func SubtitleAvailableHandler(c *gin.Context) {
 	movieID, err := strconv.Atoi(c.Param("id"))
 	if err != nil || movieID <= 0 {
@@ -23,19 +24,24 @@ func SubtitleAvailableHandler(c *gin.Context) {
 		return
 	}
 
+	all := map[string]bool{}
+
 	dir := filepath.Join(services.SubtitleCacheDir(), fmt.Sprintf("%d", movieID))
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		utils.RespondSuccess(c, http.StatusOK, gin.H{"languages": []string{}})
-		return
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".vtt") {
+				all[strings.TrimSuffix(e.Name(), ".vtt")] = true
+			}
+		}
 	}
 
-	langs := []string{}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".vtt") {
-			langs = append(langs, strings.TrimSuffix(e.Name(), ".vtt"))
-			
-		}
+	for _, lang := range services.ListAvailableLanguages(movieID) {
+		all[lang] = true
+	}
+
+	langs := make([]string, 0, len(all))
+	for l := range all {
+		langs = append(langs, l)
 	}
 	utils.RespondSuccess(c, http.StatusOK, gin.H{"languages": langs})
 }

--- a/api/torrent-service/src/services/monitor.go
+++ b/api/torrent-service/src/services/monitor.go
@@ -52,6 +52,11 @@ func monitorTorrent(t *torrent.Torrent, record *models.TorrentRecord) {
 		"file_path":  filePath,
 	})
 	log.Printf("torrent %s download complete: %s", infoHash, filePath)
+
+	var movie models.Movie
+	if err := conf.DB.Where("id = ?", record.MovieID).First(&movie).Error; err == nil && movie.TmdbID > 0 {
+		go ExtractTorrentSubtitles(t, movie.TmdbID)
+	}
 }
 
 func runProgressLoop(t *torrent.Torrent, record *models.TorrentRecord, totalLength int64, infoHash string) error {

--- a/api/torrent-service/src/services/subtitle.go
+++ b/api/torrent-service/src/services/subtitle.go
@@ -11,10 +11,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/anacrolix/torrent"
 	"torrent-service/src/conf"
 )
 
@@ -36,7 +38,15 @@ var (
 	osTokenMu  sync.RWMutex
 	osToken    string
 	osTokenExp time.Time
+
+	osLangCacheMu sync.RWMutex
+	osLangCache   = map[int]osLangEntry{}
 )
+
+type osLangEntry struct {
+	langs []string
+	exp   time.Time
+}
 
 func init() {
 	osAPIKey = os.Getenv("OPENSUBTITLES_API_KEY")
@@ -198,6 +208,90 @@ func osSearchByIMDb(imdbID, lang string) (int, error) {
 	return osSearchURL(fmt.Sprintf("imdb_id=%s", imdbID), lang)
 }
 
+// ListAvailableLanguages returns the language codes for which OpenSubtitles has
+// at least one subtitle file for the given TMDB movie ID.
+// Results are cached in memory for 1 hour to avoid repeated API calls.
+func ListAvailableLanguages(movieID int) []string {
+	osLangCacheMu.RLock()
+	entry, ok := osLangCache[movieID]
+	osLangCacheMu.RUnlock()
+	if ok && time.Now().Before(entry.exp) {
+		return entry.langs
+	}
+
+	if osAPIKey == "" {
+		return nil
+	}
+	if osUsername != "" && osPassword != "" {
+		if err := osEnsureToken(); err != nil {
+			log.Printf("subtitle: opensubtitles login failed: %v", err)
+		}
+	}
+
+	langs := osQueryAllLanguages(fmt.Sprintf("tmdb_id=%d", movieID))
+	if len(langs) == 0 {
+		if imdbID := imdbIDForTmdb(movieID); imdbID != "" {
+			langs = osQueryAllLanguages(fmt.Sprintf("imdb_id=%s", imdbID))
+		}
+	}
+
+	osLangCacheMu.Lock()
+	osLangCache[movieID] = osLangEntry{langs: langs, exp: time.Now().Add(time.Hour)}
+	osLangCacheMu.Unlock()
+	log.Printf("subtitle: movie %d — available languages: %v", movieID, langs)
+	return langs
+}
+
+// osQueryAllLanguages fetches all subtitles for a movie (no language filter) and
+// returns the deduplicated list of ISO 639-1 language codes available.
+func osQueryAllLanguages(query string) []string {
+	req, _ := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("%s/subtitles?%s&type=movie", openSubsBaseURL, query), nil)
+	osSetHeaders(req)
+
+	resp, err := osClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data []struct {
+			Attributes struct {
+				Language string `json:"language"`
+				Files    []struct {
+					FileID int `json:"file_id"`
+				} `json:"files"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	var langs []string
+	for _, d := range result.Data {
+		if len(d.Attributes.Files) == 0 {
+			continue
+		}
+		raw := strings.ToLower(d.Attributes.Language)
+		code, ok := langMap[raw]
+		if !ok {
+			if len(raw) == 2 {
+				code = raw
+			} else {
+				continue
+			}
+		}
+		if !seen[code] {
+			seen[code] = true
+			langs = append(langs, code)
+		}
+	}
+	return langs
+}
+
 func osDownloadLink(fileID int) (string, error) {
 	body, _ := json.Marshal(map[string]int{"file_id": fileID})
 	req, _ := http.NewRequest(http.MethodPost, openSubsBaseURL+"/download", bytes.NewReader(body))
@@ -257,4 +351,178 @@ func srtToVTT(srt []byte) string {
 		out.WriteByte('\n')
 	}
 	return out.String()
+}
+
+var assTimingRe = regexp.MustCompile(`^Dialogue:.*?(\d+:\d+:\d+\.\d+),(\d+:\d+:\d+\.\d+),.*?,.*?,.*?,.*?,.*?,.*?,.*?,(.*)$`)
+
+// assToVTT does a best-effort conversion from ASS/SSA to WebVTT.
+// It strips override tags and extracts plain cue timings and text.
+func assToVTT(ass []byte) string {
+	var out strings.Builder
+	out.WriteString("WEBVTT\n\n")
+	scanner := bufio.NewScanner(bytes.NewReader(ass))
+	for scanner.Scan() {
+		line := scanner.Text()
+		m := assTimingRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		start := strings.Replace(m[1], ".", ",", 1)
+		end := strings.Replace(m[2], ".", ",", 1)
+		// convert H:MM:SS.cc → HH:MM:SS.ccc
+		start = assTimeToCue(start)
+		end = assTimeToCue(end)
+		text := stripAssTags(m[3])
+		if text == "" {
+			continue
+		}
+		fmt.Fprintf(&out, "%s --> %s\n%s\n\n", start, end, text)
+	}
+	return out.String()
+}
+
+func assTimeToCue(t string) string {
+	// ASS uses H:MM:SS.cc (centiseconds); VTT uses HH:MM:SS.mmm
+	parts := strings.SplitN(t, ":", 3)
+	if len(parts) != 3 {
+		return t
+	}
+	h := parts[0]
+	if len(h) < 2 {
+		h = "0" + h
+	}
+	secCs := strings.SplitN(parts[2], ".", 2)
+	sec := secCs[0]
+	cs := "00"
+	if len(secCs) == 2 {
+		cs = secCs[1]
+	}
+	ms := cs + "0"
+	if len(ms) > 3 {
+		ms = ms[:3]
+	}
+	return fmt.Sprintf("%s:%s:%s.%s", h, parts[1], sec, ms)
+}
+
+var assTagRe = regexp.MustCompile(`\{[^}]*\}`)
+
+func stripAssTags(s string) string {
+	s = assTagRe.ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, `\N`, "\n")
+	s = strings.ReplaceAll(s, `\n`, "\n")
+	return strings.TrimSpace(s)
+}
+
+// langMap maps common subtitle filename tokens to ISO 639-1 codes.
+var langMap = map[string]string{
+	"en": "en", "eng": "en", "english": "en",
+	"fr": "fr", "fra": "fr", "fre": "fr", "french": "fr", "francais": "fr", "français": "fr",
+	"es": "es", "spa": "es", "spanish": "es", "espanol": "es", "español": "es",
+	"de": "de", "deu": "de", "ger": "de", "german": "de", "deutsch": "de",
+	"it": "it", "ita": "it", "italian": "it", "italiano": "it",
+	"pt": "pt", "por": "pt", "portuguese": "pt", "portugues": "pt",
+	"ru": "ru", "rus": "ru", "russian": "ru",
+	"ar": "ar", "ara": "ar", "arabic": "ar",
+	"zh": "zh", "zho": "zh", "chi": "zh", "chinese": "zh",
+	"ja": "ja", "jpn": "ja", "japanese": "ja",
+	"ko": "ko", "kor": "ko", "korean": "ko",
+	"nl": "nl", "nld": "nl", "dut": "nl", "dutch": "nl",
+	"pl": "pl", "pol": "pl", "polish": "pl",
+	"tr": "tr", "tur": "tr", "turkish": "tr",
+	"sv": "sv", "swe": "sv", "swedish": "sv",
+	"no": "no", "nor": "no", "norwegian": "no",
+	"da": "da", "dan": "da", "danish": "da",
+	"fi": "fi", "fin": "fi", "finnish": "fi",
+	"cs": "cs", "ces": "cs", "cze": "cs", "czech": "cs",
+	"hu": "hu", "hun": "hu", "hungarian": "hu",
+	"ro": "ro", "ron": "ro", "rum": "ro", "romanian": "ro",
+	"he": "he", "heb": "he", "hebrew": "he",
+	"hi": "hi", "hin": "hi", "hindi": "hi",
+}
+
+// detectLangFromPath tries to extract an ISO 639-1 language code from a
+// subtitle file path. It checks each dot-separated and slash-separated
+// segment of the name against langMap.
+func detectLangFromPath(path string) string {
+	base := strings.ToLower(filepath.Base(path))
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+
+	// Check parent directory name too (e.g. "Subs/English/movie.srt")
+	dir := strings.ToLower(filepath.Base(filepath.Dir(path)))
+
+	for _, token := range append(strings.FieldsFunc(base, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-' || r == ' '
+	}), dir) {
+		if code, ok := langMap[token]; ok {
+			return code
+		}
+	}
+	return ""
+}
+
+var subtitleExts = map[string]bool{
+	".srt": true, ".vtt": true, ".ass": true, ".ssa": true, ".sub": true,
+}
+
+// ExtractTorrentSubtitles scans torrent files for subtitle tracks, converts
+// them to WebVTT, and saves them to the subtitle cache for the given TMDB ID.
+// Already-cached files are not overwritten.
+func ExtractTorrentSubtitles(t *torrent.Torrent, tmdbID int) {
+	var subtitleFiles []*torrent.File
+	for _, f := range t.Files() {
+		f := f
+		ext := strings.ToLower(filepath.Ext(f.DisplayPath()))
+		if subtitleExts[ext] {
+			subtitleFiles = append(subtitleFiles, f)
+		}
+	}
+	if len(subtitleFiles) == 0 {
+		return
+	}
+
+	// Count distinct detected languages to handle the single-file "und" case.
+	for _, f := range subtitleFiles {
+		lang := detectLangFromPath(f.DisplayPath())
+		if lang == "" {
+			if len(subtitleFiles) == 1 {
+				lang = "und"
+			} else {
+				continue
+			}
+		}
+
+		cachePath := subtitleCachePath(tmdbID, lang)
+		if _, err := os.Stat(cachePath); err == nil {
+			continue // already cached
+		}
+
+		r := f.NewReader()
+		raw, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			log.Printf("subtitle: torrent extract read error %s: %v", f.DisplayPath(), err)
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(f.DisplayPath()))
+		var vtt string
+		switch ext {
+		case ".vtt":
+			vtt = string(raw)
+		case ".ass", ".ssa":
+			vtt = assToVTT(raw)
+		default: // .srt, .sub
+			vtt = srtToVTT(raw)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
+			log.Printf("subtitle: torrent extract mkdir error: %v", err)
+			continue
+		}
+		if err := os.WriteFile(cachePath, []byte(vtt), 0644); err != nil {
+			log.Printf("subtitle: torrent extract write error: %v", err)
+			continue
+		}
+		log.Printf("subtitle: extracted %s → %s (lang=%s)", f.DisplayPath(), cachePath, lang)
+	}
 }

--- a/api/torrent-service/src/services/subtitle.go
+++ b/api/torrent-service/src/services/subtitle.go
@@ -337,11 +337,19 @@ func fetchURL(url string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
+// stripBOM removes a leading UTF-8 byte order mark if present.
+func stripBOM(b []byte) []byte {
+	if len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
+		return b[3:]
+	}
+	return b
+}
+
 // srtToVTT converts SRT subtitle bytes to WebVTT format.
 func srtToVTT(srt []byte) string {
 	var out strings.Builder
 	out.WriteString("WEBVTT\n\n")
-	scanner := bufio.NewScanner(bytes.NewReader(srt))
+	scanner := bufio.NewScanner(bytes.NewReader(stripBOM(srt)))
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, " --> ") {
@@ -477,23 +485,27 @@ func ExtractTorrentSubtitles(t *torrent.Torrent, tmdbID int) {
 		}
 	}
 	if len(subtitleFiles) == 0 {
+		log.Printf("subtitle: torrent movie %d — no subtitle files found", tmdbID)
 		return
 	}
+	log.Printf("subtitle: torrent movie %d — found %d subtitle file(s)", tmdbID, len(subtitleFiles))
 
-	// Count distinct detected languages to handle the single-file "und" case.
+	undIdx := 0
 	for _, f := range subtitleFiles {
 		lang := detectLangFromPath(f.DisplayPath())
 		if lang == "" {
-			if len(subtitleFiles) == 1 {
+			if undIdx == 0 {
 				lang = "und"
 			} else {
-				continue
+				lang = fmt.Sprintf("und_%d", undIdx)
 			}
+			undIdx++
 		}
 
 		cachePath := subtitleCachePath(tmdbID, lang)
 		if _, err := os.Stat(cachePath); err == nil {
-			continue // already cached
+			log.Printf("subtitle: torrent %s already cached (lang=%s)", f.DisplayPath(), lang)
+			continue
 		}
 
 		r := f.NewReader()
@@ -508,7 +520,7 @@ func ExtractTorrentSubtitles(t *torrent.Torrent, tmdbID int) {
 		var vtt string
 		switch ext {
 		case ".vtt":
-			vtt = string(raw)
+			vtt = string(stripBOM(raw))
 		case ".ass", ".ssa":
 			vtt = assToVTT(raw)
 		default: // .srt, .sub
@@ -523,6 +535,6 @@ func ExtractTorrentSubtitles(t *torrent.Torrent, tmdbID int) {
 			log.Printf("subtitle: torrent extract write error: %v", err)
 			continue
 		}
-		log.Printf("subtitle: extracted %s → %s (lang=%s)", f.DisplayPath(), cachePath, lang)
+		log.Printf("subtitle: extracted %s → %s (lang=%s, %d bytes)", f.DisplayPath(), cachePath, lang, len(vtt))
 	}
 }

--- a/frontend/src/hooks/useSubtitleTracks.ts
+++ b/frontend/src/hooks/useSubtitleTracks.ts
@@ -37,8 +37,10 @@ export function useSubtitleTracks(
 
       if (cancelled) return
 
+      // The API returns all languages that exist (cached or on OpenSubtitles).
+      // Load all of them so the player can offer every available track.
       if (available.length === 0) {
-        setStatus('none')
+        if (!cancelled) setStatus('none')
         return
       }
 
@@ -49,7 +51,8 @@ export function useSubtitleTracks(
         return
       }
 
-      // 3. Load each available language as a blob-URL track.
+      // 3. Load each language as a blob-URL track (backend downloads if not cached).
+      let loaded = 0
       for (const lang of available) {
         if (cancelled) break
         try {
@@ -68,10 +71,11 @@ export function useSubtitleTracks(
           el.src = url
           if (lang === userLang) el.default = true
           video.appendChild(el)
+          loaded++
         } catch { /* not available for this language */ }
       }
 
-      if (!cancelled) setStatus('available')
+      if (!cancelled) setStatus(loaded > 0 ? 'available' : 'none')
     })()
 
     return () => {


### PR DESCRIPTION
## Summary

- **Backend** — `SubtitleAvailableHandler` retourne maintenant les langues en cache disque **ET** celles disponibles sur OpenSubtitles (une seule requête sans filtre de langue, résultat mis en cache mémoire 1h), ce qui évite tous les 400 côté frontend
- **Backend** — `ListAvailableLanguages()` : requête OpenSubtitles avec `?tmdb_id=X&type=movie` sans filtre langue, fallback IMDb ID, cache mémoire 1h par film
- **Fix** — Strip du BOM UTF-8 en tête des fichiers SRT/VTT avant conversion → corrigeait un cue identifier corrompu rejeté par le navigateur
- **Fix** — Les fichiers sous-titres sans langue détectable dans le nom n'étaient plus skippés silencieusement : ils reçoivent désormais `und` / `und_1` / `und_2`…
- **Fix** — `ExtractTorrentSubtitles` est déclenché dès que le téléchargement du torrent est complet
- **Frontend** — `useSubtitleTracks` charge toutes les langues confirmées par l'API au lieu d'essayer `[userLang, 'en']` à l'aveugle

## Test plan

- [ ] Vérifier dans les logs `subtitle: movie X — available languages: [...]` au premier chargement, absent sur les suivants (cache 1h)
- [ ] Ouvrir un film avec sous-titres torrent : vérifier `subtitle: torrent movie X — found N subtitle file(s)` et `extracted ... (lang=..., N bytes)`
- [ ] Confirmer qu'aucune requête `/subtitles/:lang` ne retourne 400 dans la console réseau
- [ ] Vérifier que toutes les pistes apparaissent dans le sélecteur du player
- [ ] Vérifier que la langue de l'utilisateur est `default` si disponible