### PR TITLE
refactor(frontend): centralize API calls via shared apiClient

### DIFF
--- a/frontend/src/app/(main)/admin/films/hooks/useAdminFilms.ts
+++ b/frontend/src/app/(main)/admin/films/hooks/useAdminFilms.ts
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { apiClient } from '@/lib/api'
 
 export interface AdminTorrent {
   id: number
@@ -35,11 +36,13 @@ export function useAdminFilms() {
   const fetchFilms = React.useCallback(async (off: number) => {
     setLoading(true)
     try {
-      const res = await fetch(`/api/v1/admin/films?limit=${LIMIT}&offset=${off}`, { credentials: 'include' })
-      if (!res.ok) return
-      const json = await res.json()
+      const json = await apiClient.get<{ data: { films: AdminGroupedFilm[]; pagination: { total: number } } }>(
+        `/admin/films?limit=${LIMIT}&offset=${off}`,
+      )
       setFilms(json.data?.films ?? [])
       setTotal(json.data?.pagination?.total ?? 0)
+    } catch {
+      // keep previous state on error
     } finally {
       setLoading(false)
     }
@@ -56,7 +59,7 @@ export function useAdminFilms() {
     setActionId(torrentId)
     setActionType('delete')
     try {
-      await fetch(`/api/v1/admin/films/${torrentId}`, { method: 'DELETE', credentials: 'include' })
+      await apiClient.delete(`/admin/films/${torrentId}`)
       await fetchFilms(offset)
     } finally {
       setActionId(null)
@@ -68,7 +71,7 @@ export function useAdminFilms() {
     setActionId(torrentId)
     setActionType('redownload')
     try {
-      await fetch(`/api/v1/admin/films/${torrentId}/download`, { method: 'POST', credentials: 'include' })
+      await apiClient.post(`/admin/films/${torrentId}/download`)
       await fetchFilms(offset)
     } finally {
       setActionId(null)

--- a/frontend/src/app/(main)/admin/overview/page.tsx
+++ b/frontend/src/app/(main)/admin/overview/page.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Loader2, Users, Film, Eye, TrendingUp } from 'lucide-react'
+import { apiClient } from '@/lib/api'
 import {
   AreaChart, Area,
   BarChart, Bar,
@@ -49,9 +50,9 @@ export default function AdminOverviewPage() {
   const [loading, setLoading] = React.useState(true)
 
   React.useEffect(() => {
-    fetch('/api/v1/admin/stats', { credentials: 'include' })
-      .then((r) => r.json())
+    apiClient.get<{ data: AdminStats }>('/admin/stats')
       .then((json) => setStats(json.data ?? null))
+      .catch(() => {})
       .finally(() => setLoading(false))
   }, [])
 

--- a/frontend/src/app/(main)/admin/users/page.tsx
+++ b/frontend/src/app/(main)/admin/users/page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Loader2, Pencil, Shield, Trash2 } from 'lucide-react'
+import { apiClient } from '@/lib/api'
 
 interface AdminUser {
   id: number
@@ -99,8 +100,7 @@ export default function AdminUsersPage() {
   const limit = 20
 
   React.useEffect(() => {
-    fetch('/api/v1/users/profile', { credentials: 'include' })
-      .then(r => r.json())
+    apiClient.get<{ data: { id: number } }>('/users/profile')
       .then(json => { if (json.data?.id) setCurrentUserId(json.data.id) })
       .catch(() => {})
   }, [])
@@ -108,11 +108,13 @@ export default function AdminUsersPage() {
   const fetchUsers = React.useCallback(async (off: number) => {
     setLoading(true)
     try {
-      const res = await fetch(`/api/v1/admin/users?limit=${limit}&offset=${off}`, { credentials: 'include' })
-      if (!res.ok) return
-      const json = await res.json()
+      const json = await apiClient.get<{ data: { users: AdminUser[]; pagination: { total: number } } }>(
+        `/admin/users?limit=${limit}&offset=${off}`,
+      )
       setUsers(json.data?.users ?? [])
       setTotal(json.data?.pagination?.total ?? 0)
+    } catch {
+      // keep previous state on error
     } finally {
       setLoading(false)
     }
@@ -129,15 +131,10 @@ export default function AdminUsersPage() {
     setActing(user.id)
     const newRole = user.role === 'admin' ? 'user' : 'admin'
     try {
-      const res = await fetch(`/api/v1/admin/users/${user.id}/role`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ role: newRole }),
-        credentials: 'include',
-      })
-      if (res.ok) {
-        setUsers(prev => prev.map(u => u.id === user.id ? { ...u, role: newRole } : u))
-      }
+      await apiClient.put(`/admin/users/${user.id}/role`, { role: newRole })
+      setUsers(prev => prev.map(u => u.id === user.id ? { ...u, role: newRole } : u))
+    } catch {
+      // keep previous state on error
     } finally {
       setActing(null)
     }
@@ -146,14 +143,11 @@ export default function AdminUsersPage() {
   const deleteUser = async (user: AdminUser) => {
     setActing(user.id)
     try {
-      const res = await fetch(`/api/v1/admin/users/${user.id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      })
-      if (res.ok) {
-        setUsers(prev => prev.filter(u => u.id !== user.id))
-        setTotal(prev => prev - 1)
-      }
+      await apiClient.delete(`/admin/users/${user.id}`)
+      setUsers(prev => prev.filter(u => u.id !== user.id))
+      setTotal(prev => prev - 1)
+    } catch {
+      // keep previous state on error
     } finally {
       setActing(null)
     }
@@ -162,15 +156,10 @@ export default function AdminUsersPage() {
   const renameUser = async (user: AdminUser, username: string) => {
     setActing(user.id)
     try {
-      const res = await fetch(`/api/v1/admin/users/${user.id}/username`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: username.trim() }),
-        credentials: 'include',
-      })
-      if (res.ok) {
-        setUsers(prev => prev.map(u => u.id === user.id ? { ...u, username: username.trim() } : u))
-      }
+      await apiClient.put(`/admin/users/${user.id}/username`, { username: username.trim() })
+      setUsers(prev => prev.map(u => u.id === user.id ? { ...u, username: username.trim() } : u))
+    } catch {
+      // keep previous state on error
     } finally {
       setActing(null)
     }

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTranslation } from 'react-i18next'
 import { CheckCircle, XCircle, Loader2, Globe, Lock, Heart } from 'lucide-react'
+import { apiClient } from '@/lib/api'
 
 const LANGUAGES = [
   { code: 'fr', label: '🇫🇷 Français' },
@@ -48,8 +49,7 @@ export default function ProfilePage() {
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
   React.useEffect(() => {
-    fetch('/api/v1/users/profile', { credentials: 'include' })
-      .then((r) => r.json())
+    apiClient.get<{ data: { profile: UserProfile } }>('/users/profile')
       .then(({ data }) => {
         const p: UserProfile = data.profile
         setProfile(p)
@@ -82,43 +82,24 @@ export default function ProfilePage() {
       if (pendingFile) {
         const form = new FormData()
         form.append('avatar', pendingFile)
-        const res = await fetch('/api/v1/users/avatar', {
-          method: 'POST',
-          credentials: 'include',
-          body: form,
-        })
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({}))
-          setErrorMsg(body.error ?? t('profile.save_error'))
-          setSaveStatus('error')
-          return
-        }
-        const { data } = await res.json()
-        setProfile((prev) => prev ? { ...prev, avatar_url: data.avatar_url } : prev)
+        const avatarJson = await apiClient.post<{ data: { avatar_url: string } }>('/users/avatar', form)
+        setProfile((prev) => prev ? { ...prev, avatar_url: avatarJson.data.avatar_url } : prev)
         setLocalPreview('')
         setPendingFile(null)
       }
 
-      const res = await fetch(`/api/v1/users/profile/${profile.id}`, {
-        method: 'PUT',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ first_name: firstName, last_name: lastName, language: selectedLang, is_public: isPublic, favorites_public: favoritesPublic }),
-      })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        setErrorMsg(body.error ?? t('profile.save_error'))
-        setSaveStatus('error')
-        return
-      }
-      const { data } = await res.json()
-      setProfile(data.profile)
+      const profileJson = await apiClient.put<{ data: { profile: UserProfile } }>(
+        `/users/profile/${profile.id}`,
+        { first_name: firstName, last_name: lastName, language: selectedLang, is_public: isPublic, favorites_public: favoritesPublic },
+      )
+      setProfile(profileJson.data.profile)
       await i18n.changeLanguage(selectedLang)
       setSaveStatus('success')
       setIsEditing(false)
       setTimeout(() => setSaveStatus('idle'), 3000)
-    } catch {
-      setErrorMsg(t('profile.save_error'))
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : ''
+      setErrorMsg(message || t('profile.save_error'))
       setSaveStatus('error')
     }
   }

--- a/frontend/src/app/(main)/users/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { useTranslation } from 'react-i18next'
 import { MovieCard } from '@/components/page/MovieCard'
 import type { Movie } from '@/hooks/useMovies'
+import { apiClient, ApiError } from '@/lib/api'
 
 interface PublicProfile {
   id: number
@@ -64,23 +65,19 @@ export default function PublicProfilePage() {
   const [privateAccount, setPrivateAccount] = React.useState(false)
 
   React.useEffect(() => {
-    fetch(`/api/v1/users/profile/${id}`, { credentials: 'include' })
-      .then((r) => {
-        if (r.status === 404) { setNotFound(true); return null }
-        if (r.status === 403) { setPrivateAccount(true); return null }
-        return r.json()
+    apiClient.get<{ data: { profile: PublicProfile } }>(`/users/profile/${id}`)
+      .then(({ data }) => setProfile(data.profile))
+      .catch((err: unknown) => {
+        if (err instanceof ApiError && err.status === 403) setPrivateAccount(true)
+        else setNotFound(true)
       })
-      .then((body) => { if (body) setProfile(body.data.profile) })
-      .catch(() => setNotFound(true))
 
-    fetch(`/api/v1/comments/user/${id}`, { credentials: 'include' })
-      .then((r) => r.json())
+    apiClient.get<{ data: UserComment[] }>(`/comments/user/${id}`)
       .then(({ data }) => setComments(data ?? []))
       .catch(() => {})
 
-    fetch(`/api/v1/users/${id}/favorites?limit=50`, { credentials: 'include' })
-      .then((r) => r.ok ? r.json() : null)
-      .then((body) => { if (body) setFavorites(body.data?.favorites ?? []) })
+    apiClient.get<{ data: { favorites: FavoriteMovie[] } }>(`/users/${id}/favorites?limit=50`)
+      .then(({ data }) => setFavorites(data?.favorites ?? []))
       .catch(() => {})
   }, [id])
 

--- a/frontend/src/components/page/CommentSection.tsx
+++ b/frontend/src/components/page/CommentSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { apiClient } from '@/lib/api'
 
 interface Comment {
   id: number
@@ -40,15 +41,11 @@ export function CommentSection({ movieId, initialComments }: CommentSectionProps
     setError(null)
 
     try {
-      const res = await fetch(`/api/v1/comments/${movieId}`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: content.trim() }),
-      })
-      if (!res.ok) throw new Error(`${res.status}`)
-      const json = await res.json()
-      const newComment: Comment = json.data ?? json
+      const json = await apiClient.post<{ data?: Comment } & Comment>(
+        `/comments/${movieId}`,
+        { content: content.trim() },
+      )
+      const newComment: Comment = (json.data ?? json) as Comment
       setComments(prev => [newComment, ...prev])
       setContent('')
     } catch {
@@ -60,13 +57,8 @@ export function CommentSection({ movieId, initialComments }: CommentSectionProps
 
   const handleDelete = async (commentId: number) => {
     try {
-      const res = await fetch(`/api/v1/comments/${commentId}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      })
-      if (res.ok) {
-        setComments(prev => prev.filter(c => c.id !== commentId))
-      }
+      await apiClient.delete(`/comments/${commentId}`)
+      setComments(prev => prev.filter(c => c.id !== commentId))
     } catch {
       // silently ignore
     }

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { apiClient } from '@/lib/api'
 
 export interface FavoriteMovie {
   tmdb_id: number
@@ -16,10 +17,9 @@ export function useFavorites() {
   const [loading, setLoading] = React.useState(true)
 
   React.useEffect(() => {
-    fetch('/api/v1/users/favorites?limit=500', { credentials: 'include' })
-      .then((r) => r.json())
+    apiClient.get<{ data: { favorites: FavoriteMovie[] } }>('/users/favorites?limit=500')
       .then((json) => {
-        const movies: FavoriteMovie[] = json.data?.favorites ?? []
+        const movies = json.data?.favorites ?? []
         setList(movies)
         setFavorites(new Set(movies.map((f) => f.tmdb_id)))
       })
@@ -41,14 +41,9 @@ export function useFavorites() {
 
     try {
       if (was) {
-        await fetch(`/api/v1/users/favorites/${tmdbId}`, { method: 'DELETE', credentials: 'include' })
+        await apiClient.delete(`/users/favorites/${tmdbId}`)
       } else {
-        await fetch('/api/v1/users/favorites', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tmdb_id: tmdbId }),
-        })
+        await apiClient.post('/users/favorites', { tmdb_id: tmdbId })
       }
     } catch {
       setFavorites((prev) => {

--- a/frontend/src/hooks/useMovies.ts
+++ b/frontend/src/hooks/useMovies.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { apiClient } from '@/lib/api'
 
 export interface Movie {
   id: number
@@ -42,6 +43,8 @@ export function useMovies(filters: MovieFilters) {
   const [hasMore, setHasMore] = useState(true)
   const abortRef = useRef<AbortController | null>(null)
 
+  const validYear = isValidYear(filters.year) ? filters.year : ''
+
   const fetchMovies = useCallback(async (cursor: string | null, reset: boolean) => {
     if (abortRef.current) abortRef.current.abort()
     const controller = new AbortController()
@@ -53,17 +56,15 @@ export function useMovies(filters: MovieFilters) {
     if (filters.query) params.set('q', filters.query)
     if (filters.genre) params.set('genre', filters.genre)
     if (filters.rating) params.set('rating', filters.rating)
-    if (isValidYear(filters.year)) params.set('year', filters.year)
+    if (validYear) params.set('year', validYear)
     if (filters.sort_by) params.set('sort_by', filters.sort_by)
     if (cursor) params.set('cursor', cursor)
 
     try {
-      const res = await fetch(`/api/v1/library/movies?${params.toString()}`, {
-        signal: controller.signal,
-        credentials: 'include',
-      })
-      if (!res.ok) throw new Error('fetch failed')
-      const json: MoviesResponse = await res.json()
+      const json = await apiClient.get<MoviesResponse>(
+        `/library/movies?${params.toString()}`,
+        { signal: controller.signal },
+      )
       const { results, next_cursor } = json.data
 
       setMovies(prev => {
@@ -80,7 +81,8 @@ export function useMovies(filters: MovieFilters) {
       setLoading(false)
       setInitialLoading(false)
     }
-  }, [filters.query, filters.genre, filters.rating, isValidYear(filters.year) ? filters.year : '', filters.sort_by])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.query, filters.genre, filters.rating, validYear, filters.sort_by])
 
   useEffect(() => {
     setInitialLoading(true)

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { apiClient } from '@/lib/api'
 
 const SAVE_INTERVAL_MS = 5000
 
@@ -18,9 +19,9 @@ export function useProgressSync(
       const video = videoRef.current
       if (!video || cancelled) return
       try {
-        const res = await fetch(`/api/v1/movies/${movieId}/progress`, { credentials: 'include' })
-        if (!res.ok || cancelled) return
-        const json = await res.json()
+        const json = await apiClient.get<{ data?: { progress_sec?: number }; progress_sec?: number }>(
+          `/movies/${movieId}/progress`,
+        )
         const sec: number = (json.data ?? json).progress_sec ?? 0
         if (sec > 0 && videoRef.current) videoRef.current.currentTime = sec
       } catch { /* start from beginning */ }
@@ -33,7 +34,7 @@ export function useProgressSync(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isStreaming, movieId])
 
-  // Save position every SAVE_INTERVAL_MS with PUT only — no GET here.
+  // Save position every SAVE_INTERVAL_MS.
   useEffect(() => {
     if (!isStreaming) return
 
@@ -43,12 +44,7 @@ export function useProgressSync(
       const sec = Math.floor(video.currentTime)
       if (sec <= 0) return
       try {
-        await fetch(`/api/v1/movies/${movieId}/progress`, {
-          method: 'PUT',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ progress_sec: sec }),
-        })
+        await apiClient.put(`/movies/${movieId}/progress`, { progress_sec: sec })
       } catch { /* ignore transient errors */ }
     }, SAVE_INTERVAL_MS)
 

--- a/frontend/src/hooks/useTorrentStream.ts
+++ b/frontend/src/hooks/useTorrentStream.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { apiClient } from '@/lib/api'
 
 export type PlayerState = 'idle' | 'checking' | 'starting' | 'downloading' | 'streaming' | 'error'
 
@@ -14,6 +15,15 @@ export interface Torrent {
   seeds: number
   peers: number
   magnet: string
+}
+
+interface TorrentStatusResponse {
+  data?: { status?: string; progress?: number }
+}
+
+interface TorrentDownloadResponse {
+  data?: { info_hash?: string }
+  info_hash?: string
 }
 
 export function useTorrentStream(initialTorrent: Torrent | null, movieId: number) {
@@ -40,8 +50,7 @@ export function useTorrentStream(initialTorrent: Torrent | null, movieId: number
     void (async () => {
       const hash = selected.hash.toLowerCase()
       try {
-        // 200 = streamable now; 202 = pending (not ready yet)
-        const head = await fetch(`/api/v1/stream/${hash}`, { method: 'HEAD', credentials: 'include' })
+        const head = await apiClient.head(`/stream/${hash}`)
         if (!cancelled && head.status === 200) {
           setInfoHash(hash)
           setState('streaming')
@@ -50,15 +59,13 @@ export function useTorrentStream(initialTorrent: Torrent | null, movieId: number
       } catch { /* fall through to status check */ }
       if (cancelled) return
       try {
-        const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
+        const json = await apiClient.get<TorrentStatusResponse>(`/torrent/status/${hash}`)
         if (cancelled) return
-        if (res.ok) {
-          const { status } = ((await res.json()).data ?? {}) as { status?: string }
-          if (!cancelled && status === 'ready') {
-            setInfoHash(hash)
-            setState('streaming')
-            return
-          }
+        const { status } = json.data ?? {}
+        if (!cancelled && status === 'ready') {
+          setInfoHash(hash)
+          setState('streaming')
+          return
         }
       } catch { /* fall through */ }
       if (!cancelled) setState('idle')
@@ -77,9 +84,8 @@ export function useTorrentStream(initialTorrent: Torrent | null, movieId: number
   const pollStatus = useCallback((hash: string) => {
     pollRef.current = setInterval(async () => {
       try {
-        const res = await fetch(`/api/v1/torrent/status/${hash}`, { credentials: 'include' })
-        if (!res.ok) return
-        const { status, progress: prog } = (await res.json()).data ?? {}
+        const json = await apiClient.get<TorrentStatusResponse>(`/torrent/status/${hash}`)
+        const { status, progress: prog } = json.data ?? {}
         if (status === 'error') {
           stopPolling()
           setState('error')
@@ -108,15 +114,11 @@ export function useTorrentStream(initialTorrent: Torrent | null, movieId: number
     setState('starting')
     setErrorMsg(null)
     try {
-      const res = await fetch('/api/v1/torrent/download', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ magnet_uri: selected.magnet, movie_id: movieId }),
+      const json = await apiClient.post<TorrentDownloadResponse>('/torrent/download', {
+        magnet_uri: selected.magnet,
+        movie_id: movieId,
       })
-      if (!res.ok) throw new Error(`${res.status}`)
-      const json = await res.json()
-      const hash = (json.data?.info_hash ?? json.info_hash as string).toLowerCase()
+      const hash = (json.data?.info_hash ?? (json as TorrentDownloadResponse).info_hash ?? '').toLowerCase()
       setInfoHash(hash)
       setState('downloading')
       pollStatus(hash)

--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { apiClient } from '@/lib/api'
 
 export interface UserResult {
   id: number
@@ -26,11 +27,11 @@ export function useUserSearch(query: string) {
     abortRef.current = controller
 
     setLoading(true)
-    fetch(`/api/v1/users/search?q=${encodeURIComponent(query.trim())}`, {
-      credentials: 'include',
-      signal: controller.signal,
-    })
-      .then((r) => r.json())
+    apiClient
+      .get<{ data: { users: UserResult[] } }>(
+        `/users/search?q=${encodeURIComponent(query.trim())}`,
+        { signal: controller.signal },
+      )
       .then((json) => setUsers(json.data?.users ?? []))
       .catch(() => {})
       .finally(() => setLoading(false))

--- a/frontend/src/hooks/useWatchLater.ts
+++ b/frontend/src/hooks/useWatchLater.ts
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { apiClient } from '@/lib/api'
 
 export interface WatchLaterMovie {
   tmdb_id: number
@@ -16,10 +17,9 @@ export function useWatchLater() {
   const [loading, setLoading] = React.useState(true)
 
   React.useEffect(() => {
-    fetch('/api/v1/users/watch-later?limit=500', { credentials: 'include' })
-      .then((r) => r.json())
+    apiClient.get<{ data: { items: WatchLaterMovie[] } }>('/users/watch-later?limit=500')
       .then((json) => {
-        const movies: WatchLaterMovie[] = json.data?.items ?? []
+        const movies = json.data?.items ?? []
         setList(movies)
         setItems(new Set(movies.map((m) => m.tmdb_id)))
       })
@@ -43,14 +43,9 @@ export function useWatchLater() {
 
     try {
       if (was) {
-        await fetch(`/api/v1/users/watch-later/${tmdbId}`, { method: 'DELETE', credentials: 'include' })
+        await apiClient.delete(`/users/watch-later/${tmdbId}`)
       } else {
-        await fetch('/api/v1/users/watch-later', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tmdb_id: tmdbId }),
-        })
+        await apiClient.post('/users/watch-later', { tmdb_id: tmdbId })
       }
     } catch {
       setItems((prev) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,52 @@
+const BASE = '/api/v1'
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const isFormData = init.body instanceof FormData
+  const { headers, ...rest } = init
+
+  const res = await fetch(`${BASE}${path}`, {
+    credentials: 'include',
+    ...rest,
+    headers: isFormData
+      ? (headers as HeadersInit | undefined)
+      : { 'Content-Type': 'application/json', ...(headers as Record<string, string>) },
+  })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(body.error ?? String(res.status), res.status)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export const apiClient = {
+  get: <T>(path: string, init?: RequestInit) =>
+    request<T>(path, { ...init, method: 'GET' }),
+
+  post: <T>(path: string, body?: unknown, init?: RequestInit) =>
+    request<T>(path, {
+      ...init,
+      method: 'POST',
+      body: body instanceof FormData ? body : JSON.stringify(body),
+    }),
+
+  put: <T>(path: string, body?: unknown, init?: RequestInit) =>
+    request<T>(path, { ...init, method: 'PUT', body: JSON.stringify(body) }),
+
+  delete: <T = void>(path: string, init?: RequestInit) =>
+    request<T>(path, { ...init, method: 'DELETE' }),
+
+  head: (path: string, init?: RequestInit) =>
+    fetch(`${BASE}${path}`, { credentials: 'include', ...init, method: 'HEAD' }),
+}

--- a/frontend/src/lib/i18n-provider.tsx
+++ b/frontend/src/lib/i18n-provider.tsx
@@ -1,32 +1,7 @@
 'use client';
 
 import React from 'react';
-import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
-import enTranslation from '@/locales/en.json';
-import frTranslation from '@/locales/fr.json';
-
-const resources = {
-  en: {
-    translation: enTranslation,
-  },
-  fr: {
-    translation: frTranslation,
-  },
-};
-
-if (!i18n.isInitialized) {
-  i18n
-    .use(initReactI18next)
-    .init({
-      resources,
-      lng: 'fr',
-      fallbackLng: 'en',
-      interpolation: {
-        escapeValue: false,
-      },
-    });
-}
+import '@/lib/i18n';
 
 export function I18nProvider({ children }: { children: React.ReactNode }) {
   return <>{children}</>;


### PR DESCRIPTION
Introduces `src/lib/api.ts` — a typed `apiClient` wrapper around `fetch` that automatically sets `credentials: 'include'`, `Content-Type: application/json` (skipped for FormData), and throws an `ApiError` with the HTTP status on non-ok responses.

All client-side hooks and components previously using raw `fetch()` calls are updated to use `apiClient.get/post/put/delete/head`:
- hooks: useFavorites, useWatchLater, useMovies, useProgressSync, useTorrentStream, useUserSearch
- components/pages: CommentSection, profile, users/[id], admin/overview, admin/users, admin/films

Also deduplicates i18n initialization: `i18n-provider.tsx` now simply imports the shared `i18n.ts` module instead of re-running the full init block.
